### PR TITLE
Refactoring of Logging

### DIFF
--- a/src/zcl_aff_abap_doc_parser.clas.abap
+++ b/src/zcl_aff_abap_doc_parser.clas.abap
@@ -123,12 +123,12 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
       RETURN.
     ELSEIF lines( result_table ) > 1.
       MESSAGE i107(zaff_tools) WITH `'Title'` component_name INTO DATA(message) ##NEEDED.
-      parser_log->add_info( zcl_aff_log=>get_sy_message( ) ).
+      parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
     DATA(offset) = result_table[ 1 ]-offset.
     IF offset <> 0.
       MESSAGE i113(zaff_tools) WITH component_name INTO message ##NEEDED.
-      parser_log->add_info( zcl_aff_log=>get_sy_message( ) ).
+      parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
     DATA(length) = result_table[ 1 ]-length.
     DATA(title) = abap_doc_string+offset(length).
@@ -178,7 +178,7 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
         WHEN OTHERS.
           REPLACE key_word IN modified_abap_doc_string WITH ''.
           MESSAGE w108(zaff_tools) WITH key_word component_name INTO DATA(message) ##NEEDED.
-          parser_log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+          parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
       ENDCASE.
     ENDLOOP.
     abap_doc_string = modified_abap_doc_string.
@@ -193,12 +193,12 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
     FIND ALL OCCURRENCES OF PCRE `\$callbackClass\{@link[^\}]+\}` IN string_to_parse RESULTS DATA(result_table).
     IF lines( result_table ) = 0.
       MESSAGE w109(zaff_tools) WITH abap_doc_annotation-callback_class component_name INTO DATA(message) ##NEEDED.
-      parser_log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+      parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
       RETURN.
     ENDIF.
     IF lines( result_table ) > 1.
       MESSAGE i107(zaff_tools) WITH abap_doc_annotation-callback_class component_name INTO message ##NEEDED.
-      parser_log->add_info( zcl_aff_log=>get_sy_message( ) ).
+      parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
     DATA(offset_found) = result_table[ 1 ]-offset.
     DATA(length_found) = result_table[ 1 ]-length.
@@ -240,12 +240,12 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
 
     IF lines( mixed_result_table ) = 0.
       MESSAGE w109(zaff_tools) WITH abap_doc_annotation-default component_name INTO DATA(message) ##NEEDED.
-      parser_log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+      parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
       RETURN.
     ENDIF.
     IF lines( mixed_result_table ) > 1.
       MESSAGE i107(zaff_tools) WITH abap_doc_annotation-default component_name INTO message ##NEEDED.
-      parser_log->add_info( zcl_aff_log=>get_sy_message( ) ).
+      parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
     DATA(warning_set) = abap_false.
     LOOP AT mixed_result_table ASSIGNING FIELD-SYMBOL(<entry>).
@@ -262,7 +262,7 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
           decoded_abap_doc-default = link.
         ELSEIF warning_set = abap_false.
           MESSAGE w111(zaff_tools) WITH abap_doc_annotation-default component_name INTO message ##NEEDED.
-          parser_log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+          parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
           warning_set = abap_true.
         ENDIF.
       ENDIF.
@@ -280,12 +280,12 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
     FIND ALL OCCURRENCES OF PCRE `\$values\{@link([^\}]+)\}` IN string_to_parse RESULTS DATA(result_table).
     IF lines( result_table ) = 0.
       MESSAGE w109(zaff_tools) WITH abap_doc_annotation-values component_name INTO DATA(message) ##NEEDED.
-      parser_log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+      parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
       RETURN.
     ENDIF.
     IF lines( result_table ) > 1.
       MESSAGE i107(zaff_tools) WITH abap_doc_annotation-values component_name INTO message ##NEEDED.
-      parser_log->add_info( zcl_aff_log=>get_sy_message( ) ).
+      parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
     DATA(warning_written) = abap_false.
     LOOP AT result_table ASSIGNING FIELD-SYMBOL(<entry>).
@@ -301,7 +301,7 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
         decoded_abap_doc-enumvalues_link = link.
       ELSEIF lines( splitted ) <> 2 AND warning_written = abap_false.
         MESSAGE w111(zaff_tools) WITH abap_doc_annotation-values component_name INTO message ##NEEDED.
-        parser_log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+        parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
         warning_written = abap_true.
       ENDIF.
     ENDLOOP.
@@ -315,7 +315,7 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
     FIND ALL OCCURRENCES OF abap_doc_annotation-required IN abap_doc_string RESULTS DATA(result_table).
     IF lines( result_table ) > 1.
       MESSAGE i107(zaff_tools) WITH abap_doc_annotation-required component_name INTO DATA(message) ##NEEDED.
-      parser_log->add_info( zcl_aff_log=>get_sy_message( ) ).
+      parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
     decoded_abap_doc-required = abap_true.
     LOOP AT result_table ASSIGNING FIELD-SYMBOL(<entry>).
@@ -331,7 +331,7 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
     FIND ALL OCCURRENCES OF abap_doc_annotation-show_always IN abap_doc_string RESULTS DATA(result_table).
     IF lines( result_table ) > 1.
       MESSAGE i107(zaff_tools) WITH abap_doc_annotation-show_always component_name INTO DATA(message) ##NEEDED.
-      parser_log->add_info( zcl_aff_log=>get_sy_message( ) ).
+      parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
     decoded_abap_doc-showalways = abap_true.
     LOOP AT result_table ASSIGNING FIELD-SYMBOL(<entry>).
@@ -382,12 +382,12 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
     FIND ALL OCCURRENCES OF PCRE `\$dummyannotation[^\s]+` IN abap_doc RESULTS DATA(result_table).
     IF lines( result_table ) = 0.
       MESSAGE w109(zaff_tools) WITH abap_doc_annotation-values component_name INTO DATA(message) ##NEEDED.
-      parser_log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+      parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
       RETURN.
     ENDIF.
     IF lines( result_table ) > 1.
       MESSAGE i107(zaff_tools) WITH annotation_name component_name INTO message ##NEEDED.
-      parser_log->add_info( zcl_aff_log=>get_sy_message( ) ).
+      parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
     DATA(annotation_length) = strlen( dummy_annotation ).
     DATA(regex_of_number_expressions) = cl_abap_regex=>create_pcre( pattern     = `(\+|-)?[0-9]+(.[0-9]+)?(e(\+|-)?[0-9]+)?`
@@ -407,7 +407,7 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
         number = number_candidate.
       ELSEIF match = abap_false AND warning_written = abap_false.
         MESSAGE w110(zaff_tools) WITH annotation_name component_name INTO message ##NEEDED.
-        parser_log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+        parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
         warning_written = abap_true.
       ENDIF.
     ENDLOOP.
@@ -455,10 +455,10 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
   METHOD write_description_message.
     IF description_warning_is_needed = abap_true AND decoded_abap_doc-description IS INITIAL.
       MESSAGE w115(zaff_tools) WITH component_name INTO DATA(message) ##NEEDED.
-      parser_log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+      parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ELSEIF description_warning_is_needed = abap_true AND decoded_abap_doc-description IS NOT INITIAL.
       MESSAGE i116(zaff_tools) WITH component_name INTO message ##NEEDED.
-      parser_log->add_info( zcl_aff_log=>get_sy_message( ) ).
+      parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
   ENDMETHOD.
 

--- a/src/zcl_aff_abap_doc_parser.clas.testclasses.abap
+++ b/src/zcl_aff_abap_doc_parser.clas.testclasses.abap
@@ -158,18 +158,21 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     ).
     exp_abap_doc = VALUE #( title = `Title`  description = `This is the description` showalways = abap_true minimum = `2` default = `@link cl_aff_test_types_for_writer.data:enum_values.classic_badi` ).
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 107
-                                                                                    attr1 = `'Title'`
-                                                                                    attr2 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 107
-                                                                                    attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-show_always
-                                                                                    attr2 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 107
+                                                                                           attr1 = `'Title'`
+                                                                                           attr2 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
+
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 107
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-show_always
+                                                                                           attr2 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
 
   METHOD too_many_number_annotations.
@@ -183,18 +186,20 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     ).
     exp_abap_doc = VALUE #( description = `Here are too many number annotations`  minimum = '4' maximum = '9' ).
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 107
-                                                                                    attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-minimum
-                                                                                    attr2 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 107
-                                                                                    attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-maximum
-                                                                                    attr2 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 107
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-minimum
+                                                                                           attr2 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 107
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-maximum
+                                                                                           attr2 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
 
   METHOD too_many_default_mixed.
@@ -208,12 +213,13 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     ).
     exp_abap_doc = VALUE #( description = `Here are too many defaults`  minimum = '4' default = `"10"` required = abap_true ).
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 107
-                                                                                    attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
-                                                                                    attr2 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 107
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
+                                                                                           attr2 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
 
   METHOD too_many_default_link.
@@ -227,12 +233,13 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     ).
     exp_abap_doc = VALUE #( description = `Here are too many defaults`  minimum = '4' default = `@link cl_aff_test_types_for_writer.data:enum_values.classic_badi` required = abap_true ).
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 107
-                                                                                    attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
-                                                                                    attr2 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 107
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
+                                                                                           attr2 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
 
   METHOD too_many_default_value.
@@ -246,12 +253,13 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     ).
     exp_abap_doc = VALUE #( description = `Here are too many defaults`  minimum = '4' default = `"10"` required = abap_true ).
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 107
-                                                                                    attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
-                                                                                    attr2 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 107
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
+                                                                                           attr2 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
 
   METHOD too_many_value_links.
@@ -265,12 +273,13 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     ).
     exp_abap_doc = VALUE #( description = `Here are two many value links.` enumvalues_link = `cl_aff_test_types_for_writer.data:enum_values` required = abap_true ).
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 107
-                                                                                    attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-values
-                                                                                    attr2 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 107
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-values
+                                                                                           attr2 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
 
   METHOD too_many_callbackclasses.
@@ -284,12 +293,13 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     ).
     exp_abap_doc = VALUE #( description = `Here are too many callbackclass links.` callback_class = `cl_aff_test_types_for_writer` minimum = '4').
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 107
-                                                                                    attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-callback_class
-                                                                                    attr2 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 107
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-callback_class
+                                                                                           attr2 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
 
   METHOD too_many_required_annotations.
@@ -303,12 +313,13 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     ).
     exp_abap_doc = VALUE #( description = `Here are too many required annotations.` required = abap_true min_length = '5' max_length = '10').
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 107
-                                                                                    attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-required
-                                                                                    attr2 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 107
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-required
+                                                                                           attr2 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
 
   METHOD unknown_annotation.
@@ -322,12 +333,13 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     ).
     exp_abap_doc = VALUE #( description = `Here is a unknown annoataion.` required = abap_true ).
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 108
-                                                                                    attr1 = `$unknown`
-                                                                                    attr2 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 108
+                                                                                           attr1 = `$unknown`
+                                                                                           attr2 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD wrong_usage_callback_class.
@@ -341,12 +353,13 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     ).
     exp_abap_doc = VALUE #( description = `Wrong usage of callbackClass annotation.` default = '"4"').
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 109
-                                                                                    attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-callback_class
-                                                                                    attr2 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 109
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-callback_class
+                                                                                           attr2 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD wrong_usage_default.
@@ -372,18 +385,20 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     exp_abap_doc = VALUE #( description = `Wrong usage of default` required = abap_true ).
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
 
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 109
-                                                                                    attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
-                                                                                    attr2 = `Component Name1` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 109
-                                                                                    attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
-                                                                                    attr2 = `Component Name2` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 109
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
+                                                                                           attr2 = `Component Name1` )
+                                                             exp_component_name = `Component Name1`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 109
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
+                                                                                           attr2 = `Component Name2` )
+                                                             exp_component_name = `Component Name2`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD wrong_usage_enum_values.
@@ -397,12 +412,13 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     ).
     exp_abap_doc = VALUE #( description = `Wrong usage of values.` required = abap_true ).
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 109
-                                                                                    attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-values
-                                                                                    attr2 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 109
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-values
+                                                                                           attr2 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD wrong_value_number_annotation.
@@ -416,18 +432,20 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     ).
     exp_abap_doc = VALUE #( description = `Wrong usage of minimum and maximum.` default = '"3"' ).
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 110
-                                                                                    attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-minimum
-                                                                                    attr2 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 110
-                                                                                    attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-maximum
-                                                                                    attr2 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 110
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-minimum
+                                                                                           attr2 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 110
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-maximum
+                                                                                           attr2 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD wrong_links.
@@ -441,18 +459,20 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     ).
     exp_abap_doc = VALUE #( description = `Wrong links for default and values.` ).
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 111
-                                                                                    attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-values
-                                                                                    attr2 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 111
-                                                                                    attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
-                                                                                    attr2 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 111
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-values
+                                                                                           attr2 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 111
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
+                                                                                           attr2 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD description_at_false_position.
@@ -466,11 +486,12 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     ).
     exp_abap_doc = VALUE #( title = `Title` minimum = `12` default = `"20"`).
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 115
-                                                                                    attr1 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 115
+                                                                                           attr1 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD text_between_annotations.
@@ -484,11 +505,12 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     ).
     exp_abap_doc = VALUE #( description = `Here is text between annotation` title = `Title` required = abap_true default = `@link cl_aff_test_types_for_writer.data:enum_values.classic_badi`).
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 116
-                                                                                    attr1 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 116
+                                                                                           attr1 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
 
   METHOD title_at_wrong_position.
@@ -502,16 +524,18 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     ).
     exp_abap_doc = VALUE #( description = `Description first` title = `This is the title at wrong position` enumvalues_link = `cl_aff_test_types_for_writer.data:enum_values` ).
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 116
-                                                                                    attr1 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 113
-                                                                                    attr1 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 116
+                                                                                           attr1 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 113
+                                                                                           attr1 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/zcl_aff_generator.clas.abap
+++ b/src/zcl_aff_generator.clas.abap
@@ -91,7 +91,7 @@ CLASS zcl_aff_generator IMPLEMENTATION.
         check_mandatory_fields( structure_description ).
       CATCH cx_sy_move_cast_error.
         MESSAGE w123(zaff_tools) INTO DATA(message) ##NEEDED.
-        log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+        log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = type_description->get_relative_name( ) ).
     ENDTRY.
 
   ENDMETHOD.
@@ -100,7 +100,7 @@ CLASS zcl_aff_generator IMPLEMENTATION.
     DATA(components) = structure_description->get_components( ).
     IF NOT ( line_exists( components[ name = 'HEADER' ] ) AND line_exists( components[ name = 'FORMAT_VERSION' ] ) ).
       MESSAGE w124(zaff_tools) INTO DATA(message)  ##NEEDED.
-      log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+      log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = structure_description->get_relative_name( ) ).
     ENDIF.
   ENDMETHOD.
 

--- a/src/zcl_aff_generator.clas.testclasses.abap
+++ b/src/zcl_aff_generator.clas.testclasses.abap
@@ -478,30 +478,33 @@ CLASS ltcl_type_generator IMPLEMENTATION.
     DATA no_header TYPE lif_test_types=>ty_abap_type_no_header.
     cut->generate_type( no_header ).
     DATA(log) = cut->get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 124 )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 124 )
+                                                             exp_component_name = 'TY_ABAP_TYPE_NO_HEADER'
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD no_format_version.
     DATA no_format_version TYPE lif_test_types=>ty_abap_type_no_format.
     cut->generate_type( no_format_version ).
     DATA(log) = cut->get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 124 )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 124 )
+                                                             exp_component_name = 'TY_ABAP_TYPE_NO_FORMAT'
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD no_structure.
     DATA no_structure TYPE lif_test_types=>table_in_table.
     cut->generate_type( no_structure ).
     DATA(log) = cut->get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 123 )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 123 )
+                                                             exp_component_name = 'TABLE_IN_TABLE'
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
 

--- a/src/zcl_aff_log.clas.abap
+++ b/src/zcl_aff_log.clas.abap
@@ -23,8 +23,9 @@ CLASS zcl_aff_log DEFINITION
     METHODS:
       add_message
         IMPORTING
-          type    TYPE symsgty
-          message TYPE symsg,
+          type           TYPE symsgty
+          message        TYPE symsg
+          component_name TYPE string,
       set_max_severity
         IMPORTING
           type TYPE symsgty.
@@ -41,19 +42,19 @@ CLASS zcl_aff_log IMPLEMENTATION.
 
   METHOD zif_aff_log~add_info.
     set_max_severity( zif_aff_log=>c_message_type-info ).
-    add_message( type = zif_aff_log=>c_message_type-info message = message ).
+    add_message( type = zif_aff_log=>c_message_type-info message = message component_name = component_name ).
   ENDMETHOD.
 
 
   METHOD zif_aff_log~add_warning.
     set_max_severity( zif_aff_log=>c_message_type-warning ).
-    add_message( type = zif_aff_log=>c_message_type-warning message = message ).
+    add_message( type = zif_aff_log=>c_message_type-warning message = message component_name = component_name ).
   ENDMETHOD.
 
 
   METHOD zif_aff_log~add_error.
     set_max_severity( zif_aff_log=>c_message_type-error ).
-    add_message( type = zif_aff_log=>c_message_type-error message = message ).
+    add_message( type = zif_aff_log=>c_message_type-error message = message component_name = component_name ).
   ENDMETHOD.
 
 
@@ -62,11 +63,11 @@ CLASS zcl_aff_log IMPLEMENTATION.
 
     IF exception->get_text( ) IS NOT INITIAL.
       cl_message_helper=>set_msg_vars_for_if_msg( exception ).
-      add_message( type = message_type message = get_sy_message( ) ).
+      add_message( type = message_type message = get_sy_message( ) component_name = component_name ).
     ENDIF.
 
     IF exception->previous IS BOUND.
-      zif_aff_log~add_exception( exception = exception->previous message_type = message_type ).
+      zif_aff_log~add_exception( exception = exception->previous message_type = message_type component_name = component_name ).
     ENDIF.
   ENDMETHOD.
 
@@ -80,9 +81,10 @@ CLASS zcl_aff_log IMPLEMENTATION.
       WITH message-msgv1 message-msgv2 message-msgv3 message-msgv4
       INTO DATA(text).
 
-    APPEND VALUE #( type    = type
-                    text    = text
-                    message = get_sy_message( ) ) TO me->messages.
+    APPEND VALUE #( component_name = component_name
+                    type         = type
+                    text         = text
+                    message      = get_sy_message( ) ) TO me->messages.
   ENDMETHOD.
 
 

--- a/src/zcl_aff_tools_unit_test_helper.clas.abap
+++ b/src/zcl_aff_tools_unit_test_helper.clas.abap
@@ -9,9 +9,10 @@ CLASS zcl_aff_tools_unit_test_helper DEFINITION FINAL FOR TESTING
       "! Checks whether the message is contained in the log.
       assert_log_contains_msg
         IMPORTING
-          log         TYPE REF TO zif_aff_log
-          exp_message TYPE scx_t100key
-          exp_type    TYPE symsgty DEFAULT zif_aff_log=>c_message_type-error,
+          log                TYPE REF TO zif_aff_log
+          exp_message        TYPE scx_t100key
+          exp_type           TYPE symsgty DEFAULT zif_aff_log=>c_message_type-error
+          exp_component_name TYPE string OPTIONAL,
 
       "! Asserts that both string tables are equal, ignoring all spaces.
       assert_equals_ignore_spaces
@@ -40,12 +41,13 @@ CLASS zcl_aff_tools_unit_test_helper DEFINITION FINAL FOR TESTING
 
   PROTECTED SECTION.
   PRIVATE SECTION.
+
+
 ENDCLASS.
 
 
 
 CLASS zcl_aff_tools_unit_test_helper IMPLEMENTATION.
-
 
   METHOD assert_log_contains_msg.
     DATA(act_messages) = log->get_messages( ).
@@ -57,8 +59,14 @@ CLASS zcl_aff_tools_unit_test_helper IMPLEMENTATION.
       msgv2 = exp_message-attr2
       msgv3 = exp_message-attr3
       msgv4 = exp_message-attr4 ).
-    IF NOT line_exists( act_messages[ type = exp_type message = msg ] ).
-      cl_abap_unit_assert=>fail( msg = 'The expected message is not contained in the log' ).
+    IF exp_component_name IS SUPPLIED.
+      IF NOT line_exists( act_messages[ type = exp_type message = msg component_name = exp_component_name ] ).
+        cl_abap_unit_assert=>fail( msg = 'The expected message is not contained in the log' ).
+      ENDIF.
+    ELSE.
+      IF NOT line_exists( act_messages[ type = exp_type message = msg ] ).
+        cl_abap_unit_assert=>fail( msg = 'The expected message is not contained in the log' ).
+      ENDIF.
     ENDIF.
   ENDMETHOD.
 
@@ -133,6 +141,5 @@ CLASS zcl_aff_tools_unit_test_helper IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_equals( exp = exp_work_copy act = act_work_copy msg = 'Expected and actual abap source does not match' ).
   ENDMETHOD.
-
 
 ENDCLASS.

--- a/src/zcl_aff_tools_unit_test_helper.clas.abap
+++ b/src/zcl_aff_tools_unit_test_helper.clas.abap
@@ -63,10 +63,8 @@ CLASS zcl_aff_tools_unit_test_helper IMPLEMENTATION.
       IF NOT line_exists( act_messages[ type = exp_type message = msg component_name = exp_component_name ] ).
         cl_abap_unit_assert=>fail( msg = 'The expected message is not contained in the log' ).
       ENDIF.
-    ELSE.
-      IF NOT line_exists( act_messages[ type = exp_type message = msg ] ).
-        cl_abap_unit_assert=>fail( msg = 'The expected message is not contained in the log' ).
-      ENDIF.
+    ELSEIF NOT line_exists( act_messages[ type = exp_type message = msg ] ).
+      cl_abap_unit_assert=>fail( msg = 'The expected message is not contained in the log' ).
     ENDIF.
   ENDMETHOD.
 

--- a/src/zcl_aff_tools_unit_test_helper.clas.testclasses.abap
+++ b/src/zcl_aff_tools_unit_test_helper.clas.testclasses.abap
@@ -10,6 +10,7 @@ CLASS ltcl_unit_test_helper DEFINITION FINAL FOR TESTING
       log_contains_msg_without_env FOR TESTING RAISING cx_static_check,
       assert_no_message_severity FOR TESTING RAISING cx_static_check,
       assert_log_has_no_message FOR TESTING RAISING cx_static_check,
+      log_contains_msg_with_comp FOR TESTING RAISING cx_static_check,
       change_environment_language,
       setup,
       teardown.
@@ -34,7 +35,7 @@ CLASS ltcl_unit_test_helper IMPLEMENTATION.
     TRY.
         RAISE EXCEPTION TYPE zcx_aff_tools MESSAGE e100(zaff_tools) WITH 'TEST_ATTR'.
       CATCH zcx_aff_tools INTO DATA(exception).
-        log->add_exception( exception ).
+        log->add_exception( exception = exception component_name = '' ).
     ENDTRY.
 
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
@@ -46,7 +47,7 @@ CLASS ltcl_unit_test_helper IMPLEMENTATION.
 
     "environment language is not considered. Message still on English
     MESSAGE e100(zaff_tools) WITH 'TEST_ATTR' INTO DATA(message) ##NEEDED.
-    log->add_error( zcl_aff_log=>get_sy_message( ) ).
+    log->add_error( message = zcl_aff_log=>get_sy_message( ) component_name = 'TEST' ).
 
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
                                                              exp_message = VALUE #( msgid = 'ZAFF_TOOLS' msgno = '100' attr1 = 'TEST_ATTR' )
@@ -54,7 +55,7 @@ CLASS ltcl_unit_test_helper IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD assert_no_message_severity.
-    log->add_warning( VALUE #( msgid = 'ZAFF_TOOLS' msgno = 1 ) ).
+    log->add_warning( message = VALUE #( msgid = 'ZAFF_TOOLS' msgno = 1 ) component_name = '' ).
 
     zcl_aff_tools_unit_test_helper=>assert_log_has_no_message( log = log message_severity_threshold = zif_aff_log=>c_message_type-error ).
   ENDMETHOD.
@@ -69,6 +70,19 @@ CLASS ltcl_unit_test_helper IMPLEMENTATION.
     ELSE.
       cl_abap_unit_assert=>skip( msg = 'Skip test since the test is language depended' ).
     ENDIF.
+  ENDMETHOD.
+
+  METHOD log_contains_msg_with_comp.
+    change_environment_language( ).
+
+    "environment language is not considered. Message still on English
+    MESSAGE w100(zaff_tools) WITH 'TEST_ATTR' INTO DATA(message) ##NEEDED.
+    log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = 'EXAMPLE_COMPONENT' ).
+
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS' msgno = '100' attr1 = 'TEST_ATTR' )
+                                                             exp_component_name = 'EXAMPLE_COMPONENT'
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/zcl_aff_writer.clas.abap
+++ b/src/zcl_aff_writer.clas.abap
@@ -530,7 +530,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
     IF sy-subrc <> 0.
 *    class or interface doesn't exist
       MESSAGE w103(zaff_tools) WITH name_of_source fullname_of_type INTO DATA(message) ##NEEDED.
-      log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+      log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
     ELSE.
       DATA(constant_descr) = cl_abap_typedescr=>describe_by_name( name_of_source ).
 
@@ -548,7 +548,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
         IF sy-subrc <> 0.
 *      constant in interface does not exist
           MESSAGE w104(zaff_tools) WITH name_of_source && '=>' && name_of_constant fullname_of_type INTO message ##NEEDED.
-          log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+          log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
         ENDIF.
       ELSEIF clstype = seoc_clstype_class.
         DATA(constant_descr_clas) = CAST cl_abap_classdescr( constant_descr ).
@@ -564,7 +564,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
         IF sy-subrc <> 0.
 *      constant in class does not exits
           MESSAGE w104(zaff_tools) WITH name_of_source && '=>' && name_of_constant fullname_of_type INTO message ##NEEDED.
-          log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+          log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
         ENDIF.
       ENDIF.
       constant_as_struc = CAST cl_abap_structdescr( constant ).
@@ -653,7 +653,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
     ENDIF.
     IF is_valid = abap_false.
       MESSAGE w106(zaff_tools) WITH component_name INTO DATA(message) ##NEEDED.
-      log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+      log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
   ENDMETHOD.
 
@@ -675,11 +675,11 @@ CLASS zcl_aff_writer IMPLEMENTATION.
             is_valid = abap_true.
           ELSE.
             MESSAGE w122(zaff_tools) WITH constant_name fullname_of_type INTO DATA(message) ##NEEDED.
-            log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+            log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
           ENDIF.
         ELSE.
           MESSAGE w105(zaff_tools) WITH component_name constant_name fullname_of_type INTO message ##NEEDED.
-          log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+          log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
         ENDIF.
       ENDIF.
     ENDIF.
@@ -697,7 +697,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
     IF element_description->type_kind = cl_abap_typedescr=>typekind_utclong.
 *      No support for default with utclong
       MESSAGE w117(zaff_tools) WITH 'UTCLONG'  fullname_of_type INTO DATA(message) ##NEEDED.
-      log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+      log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
       is_valid = abap_false.
       RETURN.
     ELSEIF type = zif_aff_writer=>type_info-boolean.
@@ -743,7 +743,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
     ENDIF.
     IF is_valid = abap_false.
       MESSAGE w114(zaff_tools) WITH fullname_of_type INTO message ##NEEDED.
-      log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+      log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
     ENDIF.
   ENDMETHOD.
 
@@ -776,12 +776,12 @@ CLASS zcl_aff_writer IMPLEMENTATION.
   METHOD check_redundant_annotations.
     IF abap_doc-showalways = abap_true AND abap_doc-required = abap_true.
       MESSAGE i112(zaff_tools) WITH fullname_of_type INTO DATA(message) ##NEEDED.
-      log->add_info( zcl_aff_log=>get_sy_message( ) ).
+      log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
     ENDIF.
 
     IF abap_doc-required = abap_true AND abap_doc-default IS NOT INITIAL.
       MESSAGE w126(zaff_tools) WITH fullname_of_type INTO message ##NEEDED.
-      log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+      log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
     ENDIF.
   ENDMETHOD.
 

--- a/src/zcl_aff_writer.clas.testclasses.abap
+++ b/src/zcl_aff_writer.clas.testclasses.abap
@@ -399,11 +399,12 @@ CLASS ltcl_type_writer IMPLEMENTATION.
     DATA(is_valid) = cut->is_callback_class_valid( class_name = class_name component_name = 'Component Name' ).
     DATA(log) = cut->zif_aff_writer~get_log( ).
     cl_abap_unit_assert=>assert_equals( exp = abap_false act = is_valid ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 106
-                                                                                    attr1 = `Component Name` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 106
+                                                                                           attr1 = `Component Name` )
+                                                             exp_component_name = `Component Name`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD validate_default.

--- a/src/zcl_aff_writer_json_schema.clas.abap
+++ b/src/zcl_aff_writer_json_schema.clas.abap
@@ -872,7 +872,7 @@ CLASS zcl_aff_writer_json_schema IMPLEMENTATION.
       ENDLOOP.
       IF has_initial_component = abap_false AND abap_doc-required = abap_false AND abap_doc-default IS INITIAL.
         MESSAGE w127(zaff_tools) WITH fullname_of_type INTO DATA(message) ##NEEDED ##NO_TEXT.
-        log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+        log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
       ENDIF.
     ENDIF.
   ENDMETHOD.
@@ -968,15 +968,15 @@ CLASS zcl_aff_writer_json_schema IMPLEMENTATION.
     IF ignore_til_indent_level IS INITIAL OR ignore_til_indent_level > indent_level. "Only write message if no callback class provided
       IF abap_doc_to_check-title IS INITIAL.
         MESSAGE i119(zaff_tools) WITH 'Title' fullname_of_checked_type INTO DATA(message) ##NEEDED ##NO_TEXT.
-        log->add_info( zcl_aff_log=>get_sy_message( ) ).
+        log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_checked_type ).
       ENDIF.
 
       IF abap_doc_to_check-description IS INITIAL.
         MESSAGE i119(zaff_tools) WITH 'Description' fullname_of_checked_type INTO message ##NEEDED ##NO_TEXT.
-        log->add_info( zcl_aff_log=>get_sy_message( ) ).
+        log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_checked_type  ).
       ELSEIF strlen( abap_doc_to_check-description ) > c_max_length_of_description.
         MESSAGE w125(zaff_tools) WITH fullname_of_checked_type c_max_length_of_description INTO message ##NEEDED ##NO_TEXT.
-        log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+        log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_checked_type ).
       ENDIF.
     ENDIF.
   ENDMETHOD.
@@ -989,7 +989,7 @@ CLASS zcl_aff_writer_json_schema IMPLEMENTATION.
         json_reader->next_node( ).
         json_reader->skip_node( ).
       CATCH cx_aff_root cx_sxml_parse_error INTO DATA(exception).
-        log->add_exception( exception ).
+        log->add_exception( exception = exception component_name = `` ).
         RETURN.
     ENDTRY.
     result = abap_true.

--- a/src/zcl_aff_writer_json_schema.clas.testclasses.abap
+++ b/src/zcl_aff_writer_json_schema.clas.testclasses.abap
@@ -575,12 +575,13 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
 ( ) ).
     zcl_aff_tools_unit_test_helper=>assert_equals_ignore_spaces( act_data = act_schema exp_data = exp_schema ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 122
-                                                                                    attr1 = `CO_TEST`
-                                                                                    attr2 = `DEFAULT_LINK` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 122
+                                                                                           attr1 = `CO_TEST`
+                                                                                           attr2 = `DEFAULT_LINK` )
+                                                             exp_component_name = `DEFAULT_LINK`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD type_of_enumtype_and_co_differ.
@@ -609,12 +610,13 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
 ( ) ).
     zcl_aff_tools_unit_test_helper=>assert_equals_ignore_spaces( act_data = act_schema exp_data = exp_schema ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 108
-                                                                                    attr1 = `$hiddenabc`
-                                                                                    attr2 = `UNKNOWN_ANNOTATION` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 108
+                                                                                           attr1 = `$hiddenabc`
+                                                                                           attr2 = `UNKNOWN_ANNOTATION` )
+                                                             exp_component_name = `UNKNOWN_ANNOTATION`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD unknown_abap_doc_tag.
@@ -813,12 +815,13 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
 ( ) ).
     zcl_aff_tools_unit_test_helper=>assert_equals_ignore_spaces( act_data = act_schema exp_data = exp_schema ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 108
-                                                                                    attr1 = `$ructure`
-                                                                                    attr2 = `MY_STRUCTURE2` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 108
+                                                                                           attr1 = `$ructure`
+                                                                                           attr2 = `MY_STRUCTURE2` )
+                                                             exp_component_name = `MY_STRUCTURE2`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
 
@@ -1004,11 +1007,12 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
     DATA(test) = VALUE zcl_aff_test_types=>structure_with_different_enum( ).
     test_generator->generate_type( test ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 127
-                                                                                    attr1 = `STRUCTURE_WITH_DIFFERENT_ENUM-ENUM_WITHOUT_ALL` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 127
+                                                                                           attr1 = `STRUCTURE_WITH_DIFFERENT_ENUM-ENUM_WITHOUT_ALL` )
+                                                             exp_component_name = `STRUCTURE_WITH_DIFFERENT_ENUM-ENUM_WITHOUT_ALL`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
 
@@ -1295,12 +1299,13 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
 ( ) ).
     zcl_aff_tools_unit_test_helper=>assert_equals_ignore_spaces( act_data = act_schema_co exp_data = exp_schema ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 104
-                                                                                    attr1 = `ZCL_AFF_TEST_TYPES=>ENUM_VALUES_WRONG`
-                                                                                    attr2 = `STRUCTURE_WITH_WRONG_LINK-ELEMENT_TWO` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 104
+                                                                                           attr1 = `ZCL_AFF_TEST_TYPES=>ENUM_VALUES_WRONG`
+                                                                                           attr2 = `STRUCTURE_WITH_WRONG_LINK-ELEMENT_TWO` )
+                                                             exp_component_name = `STRUCTURE_WITH_WRONG_LINK-ELEMENT_TWO`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
 
@@ -1643,12 +1648,13 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
 ( ) ).
     log = cut->zif_aff_writer~get_log( ).
     zcl_aff_tools_unit_test_helper=>assert_equals_ignore_spaces( act_data = act_schema_co exp_data = exp_schema ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 117
-                                                                                    attr1 = `UTCLONG`
-                                                                                    attr2 = `STRUCTURE_DIFFERENT_DEFAULT-DATE_TIME_FIELD` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 117
+                                                                                           attr1 = `UTCLONG`
+                                                                                           attr2 = `STRUCTURE_DIFFERENT_DEFAULT-DATE_TIME_FIELD` )
+                                                             exp_component_name = `STRUCTURE_DIFFERENT_DEFAULT-DATE_TIME_FIELD`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD structure_with_default_problem.
@@ -1722,16 +1728,18 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
 ( ) ).
     log = cut->zif_aff_writer~get_log( ).
     zcl_aff_tools_unit_test_helper=>assert_equals_ignore_spaces( act_data = act_schema_co exp_data = exp_schema ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 126
-                                                                                    attr1 = `STRUCTURE_WITH_DEFAULT_PROBLEM-INTEGER` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 126
-                                                                                    attr1 = `STRUCTURE_WITH_DEFAULT_PROBLEM-ENUM_REQUIRED` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 126
+                                                                                           attr1 = `STRUCTURE_WITH_DEFAULT_PROBLEM-INTEGER` )
+                                                             exp_component_name = `STRUCTURE_WITH_DEFAULT_PROBLEM-INTEGER`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 126
+                                                                                           attr1 = `STRUCTURE_WITH_DEFAULT_PROBLEM-ENUM_REQUIRED` )
+                                                             exp_component_name = `STRUCTURE_WITH_DEFAULT_PROBLEM-ENUM_REQUIRED`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
 
 
   ENDMETHOD.
@@ -1846,25 +1854,28 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
     ).
     zcl_aff_tools_unit_test_helper=>assert_equals_ignore_spaces( act_data = act_schema_co exp_data = exp_schema ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 105
-                                                                                    attr1 = `WRONG_COMPONENT`
-                                                                                    attr2 = `ENUM_VALUES`
-                                                                                    attr3 = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_ONE` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 111
-                                                                                    attr1 = cl_aff_abap_doc_parser=>abap_doc_annotation-default
-                                                                                    attr2 = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_TWO` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 119
-                                                                                    attr1 = `Title`
-                                                                                    attr2 = `ENUM_VALUES-CLASSIC_BADI` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 105
+                                                                                           attr1 = `WRONG_COMPONENT`
+                                                                                           attr2 = `ENUM_VALUES`
+                                                                                           attr3 = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_ONE` )
+                                                             exp_component_name = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_ONE`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 111
+                                                                                           attr1 = cl_aff_abap_doc_parser=>abap_doc_annotation-default
+                                                                                           attr2 = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_TWO` )
+                                                             exp_component_name = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_TWO`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 119
+                                                                                           attr1 = `Title`
+                                                                                           attr2 = `ENUM_VALUES-CLASSIC_BADI` )
+                                                             exp_component_name = `ENUM_VALUES-CLASSIC_BADI`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
 
 
@@ -2281,17 +2292,19 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
 ( ) ).
     zcl_aff_tools_unit_test_helper=>assert_equals_ignore_spaces( act_data = act_schema exp_data = exp_schema ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 106
-                                                                                    attr1 = `STRUCTURE_WITH_WRONG_CALLBACK-MY_FIRST_ELEMENT` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 109
-                                                                                    attr1 = cl_aff_abap_doc_parser=>abap_doc_annotation-callback_class
-                                                                                    attr2 = `STRUCTURE_WITH_WRONG_CALLBACK-MY_SECOND_ELEMENT` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 106
+                                                                                           attr1 = `STRUCTURE_WITH_WRONG_CALLBACK-MY_FIRST_ELEMENT` )
+                                                             exp_component_name = `STRUCTURE_WITH_WRONG_CALLBACK-MY_FIRST_ELEMENT`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 109
+                                                                                           attr1 = cl_aff_abap_doc_parser=>abap_doc_annotation-callback_class
+                                                                                           attr2 = `STRUCTURE_WITH_WRONG_CALLBACK-MY_SECOND_ELEMENT` )
+                                                             exp_component_name = `STRUCTURE_WITH_WRONG_CALLBACK-MY_SECOND_ELEMENT`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD structure_no_title_descr.
@@ -2333,42 +2346,48 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
   ( ) ).
     zcl_aff_tools_unit_test_helper=>assert_equals_ignore_spaces( act_data = act_schema exp_data = exp_schema ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 119
-                                                                                    attr1 = `Title`
-                                                                                    attr2 = `STRUCTURE_NO_TITLE_DESCR` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 119
-                                                                                    attr1 = `Description`
-                                                                                    attr2 = `STRUCTURE_NO_TITLE_DESCR` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 119
-                                                                                    attr1 = `Title`
-                                                                                    attr2 = `STRUCTURE_NO_TITLE_DESCR-FIELD1` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 119
-                                                                                    attr1 = `Description`
-                                                                                    attr2 = `STRUCTURE_NO_TITLE_DESCR-INNER_STRUC` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                        msgno = 119
-                                                                                        attr1 = `Title`
-                                                                                        attr2 = `STRUCTURE_NO_TITLE_DESCR-INNER_TABLE` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 119
-                                                                                    attr1 = `Description`
-                                                                                    attr2 = `STRUCTURE_NO_TITLE_DESCR-INNER_TABLE` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 119
+                                                                                           attr1 = `Title`
+                                                                                           attr2 = `STRUCTURE_NO_TITLE_DESCR` )
+                                                             exp_component_name = `STRUCTURE_NO_TITLE_DESCR`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 119
+                                                                                           attr1 = `Description`
+                                                                                           attr2 = `STRUCTURE_NO_TITLE_DESCR` )
+                                                             exp_component_name = `STRUCTURE_NO_TITLE_DESCR`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 119
+                                                                                           attr1 = `Title`
+                                                                                           attr2 = `STRUCTURE_NO_TITLE_DESCR-FIELD1` )
+                                                             exp_component_name = `STRUCTURE_NO_TITLE_DESCR-FIELD1`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 119
+                                                                                           attr1 = `Description`
+                                                                                           attr2 = `STRUCTURE_NO_TITLE_DESCR-INNER_STRUC` )
+                                                             exp_component_name = `STRUCTURE_NO_TITLE_DESCR-INNER_STRUC`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                               msgno = 119
+                                                                                               attr1 = `Title`
+                                                                                               attr2 = `STRUCTURE_NO_TITLE_DESCR-INNER_TABLE` )
+                                                             exp_component_name = `STRUCTURE_NO_TITLE_DESCR-INNER_TABLE`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 119
+                                                                                           attr1 = `Description`
+                                                                                           attr2 = `STRUCTURE_NO_TITLE_DESCR-INNER_TABLE` )
+                                                             exp_component_name = `STRUCTURE_NO_TITLE_DESCR-INNER_TABLE`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
 
   METHOD element_no_title_descr.
@@ -2383,18 +2402,20 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
     ( ) ).
     zcl_aff_tools_unit_test_helper=>assert_equals_ignore_spaces( act_data = act_schema exp_data = exp_schema ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 119
-                                                                                    attr1 = `Title`
-                                                                                    attr2 = `ELEMENT_NO_TITLE_DESCR` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 119
-                                                                                    attr1 = `Description`
-                                                                                    attr2 = `ELEMENT_NO_TITLE_DESCR` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 119
+                                                                                           attr1 = `Title`
+                                                                                           attr2 = `ELEMENT_NO_TITLE_DESCR` )
+                                                             exp_component_name = `ELEMENT_NO_TITLE_DESCR`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 119
+                                                                                           attr1 = `Description`
+                                                                                           attr2 = `ELEMENT_NO_TITLE_DESCR` )
+                                                             exp_component_name = `ELEMENT_NO_TITLE_DESCR`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
 
   METHOD table_no_title_descr.
@@ -2412,18 +2433,20 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
     ( ) ).
     zcl_aff_tools_unit_test_helper=>assert_equals_ignore_spaces( act_data = act_schema exp_data = exp_schema ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 119
-                                                                                    attr1 = `Title`
-                                                                                    attr2 = `TABLE_NO_TITLE_DESCR` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 119
-                                                                                    attr1 = `Description`
-                                                                                    attr2 = `TABLE_NO_TITLE_DESCR` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 119
+                                                                                           attr1 = `Title`
+                                                                                           attr2 = `TABLE_NO_TITLE_DESCR` )
+                                                             exp_component_name = `TABLE_NO_TITLE_DESCR`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 119
+                                                                                           attr1 = `Description`
+                                                                                           attr2 = `TABLE_NO_TITLE_DESCR` )
+                                                             exp_component_name = `TABLE_NO_TITLE_DESCR`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
 
   METHOD structure_with_include.
@@ -2507,30 +2530,33 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
     ( ) ).
     zcl_aff_tools_unit_test_helper=>assert_equals_ignore_spaces( act_data = act_schema exp_data = exp_schema ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 119
-                                                                                    attr1 = `Title`
-                                                                                    attr2 = `STRUCTURE_WITH_INCLUDE-OTHER_ELEMENT` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 119
-                                                                                    attr1 = `Description`
-                                                                                    attr2 = `TY_INCLUDE_TYPE-FIRST_ELEMENT` )
-                                                             exp_type    = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 119
+                                                                                           attr1 = `Title`
+                                                                                           attr2 = `STRUCTURE_WITH_INCLUDE-OTHER_ELEMENT` )
+                                                             exp_component_name = `STRUCTURE_WITH_INCLUDE-OTHER_ELEMENT`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 119
+                                                                                           attr1 = `Description`
+                                                                                           attr2 = `TY_INCLUDE_TYPE-FIRST_ELEMENT` )
+                                                             exp_component_name = `TY_INCLUDE_TYPE-FIRST_ELEMENT`
+                                                             exp_type           = zif_aff_log=>c_message_type-info ).
 
   ENDMETHOD.
 
   METHOD description_too_long.
     test_generator->generate_type( VALUE zcl_aff_test_types=>type_with_long_description( ) ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 125
-                                                                                    attr1 = `TYPE_WITH_LONG_DESCRIPTION`
-                                                                                    attr2 = zcl_aff_writer_json_schema=>c_max_length_of_description )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 125
+                                                                                           attr1 = `TYPE_WITH_LONG_DESCRIPTION`
+                                                                                           attr2 = zcl_aff_writer_json_schema=>c_max_length_of_description )
+                                                             exp_component_name = `TYPE_WITH_LONG_DESCRIPTION`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD get_extrema.

--- a/src/zcl_aff_writer_xslt.clas.abap
+++ b/src/zcl_aff_writer_xslt.clas.abap
@@ -545,7 +545,7 @@ CLASS zcl_aff_writer_xslt IMPLEMENTATION.
       ENDLOOP.
       IF has_initial_component = abap_false AND abap_doc-required = abap_false AND abap_doc-default IS INITIAL.
         MESSAGE w127(zaff_tools) WITH fullname_of_type INTO DATA(message) ##NEEDED ##NO_TEXT.
-        log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+        log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
       ENDIF.
     ENDIF.
   ENDMETHOD.
@@ -561,7 +561,7 @@ CLASS zcl_aff_writer_xslt IMPLEMENTATION.
   METHOD get_default_value_from_default.
     IF element_description->type_kind = cl_abap_typedescr=>typekind_utclong.
       MESSAGE w117(zaff_tools) WITH 'UTCLONG'  fullname_of_type INTO DATA(message) ##NEEDED.
-      log->add_warning( zcl_aff_log=>get_sy_message( ) ).
+      log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
       RETURN.
     ENDIF.
 
@@ -712,7 +712,7 @@ CLASS zcl_aff_writer_xslt IMPLEMENTATION.
     IF lines( errors ) > 0 OR exception IS BOUND.
       LOOP AT errors ASSIGNING FIELD-SYMBOL(<error>).
         cl_message_helper=>set_msg_vars_for_clike( <error>-text ).
-        log->add_error( VALUE #( msgid = 'ZAFF_TOOLS' msgv1 = sy-msgv1 msgv2 = sy-msgv2 msgv3 = sy-msgv3 msgv4 = sy-msgv4 ) ).
+        log->add_error( message = VALUE #( msgid = 'ZAFF_TOOLS' msgv1 = sy-msgv1 msgv2 = sy-msgv2 msgv3 = sy-msgv3 msgv4 = sy-msgv4 ) component_name = `` ).
       ENDLOOP.
       RETURN.
     ENDIF.

--- a/src/zcl_aff_writer_xslt.clas.testclasses.abap
+++ b/src/zcl_aff_writer_xslt.clas.testclasses.abap
@@ -31,7 +31,7 @@ INTERFACE lif_test_types.
   TYPES:
     BEGIN OF include_in_include.
       INCLUDE TYPE include.
-  TYPES END OF include_in_include.
+TYPES END OF include_in_include.
 
   TYPES:
     BEGIN OF structure_include_in_include.
@@ -1842,12 +1842,13 @@ CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
 `</tt:cond>`.
     validate_output( act = act_output no_log_check = abap_true ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 108
-                                                                                    attr1 = `$ructure`
-                                                                                    attr2 = `MY_STRUCTURE2` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 108
+                                                                                           attr1 = `$ructure`
+                                                                                           attr2 = `MY_STRUCTURE2` )
+                                                             exp_component_name = `MY_STRUCTURE2`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD structure_in_structure.
@@ -1944,11 +1945,12 @@ CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
     DATA test_type TYPE zcl_aff_test_types=>structure_with_different_enum.
     test_generator->generate_type( test_type ).
     DATA(log) = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 127
-                                                                                    attr1 = `STRUCTURE_WITH_DIFFERENT_ENUM-ENUM_WITHOUT_ALL` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 127
+                                                                                           attr1 = `STRUCTURE_WITH_DIFFERENT_ENUM-ENUM_WITHOUT_ALL` )
+                                                             exp_component_name = `STRUCTURE_WITH_DIFFERENT_ENUM-ENUM_WITHOUT_ALL`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
 
 
   ENDMETHOD.
@@ -1987,12 +1989,13 @@ CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
 `</tt:cond>`.
     validate_output( act = act_output no_log_check = abap_true ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 104
-                                                                                    attr1 = `ZCL_AFF_TEST_TYPES=>ENUM_VALUES_WRONG`
-                                                                                    attr2 = `STRUCTURE_WITH_WRONG_LINK-ELEMENT_TWO` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 104
+                                                                                           attr1 = `ZCL_AFF_TEST_TYPES=>ENUM_VALUES_WRONG`
+                                                                                           attr2 = `STRUCTURE_WITH_WRONG_LINK-ELEMENT_TWO` )
+                                                             exp_component_name = `STRUCTURE_WITH_WRONG_LINK-ELEMENT_TWO`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD structure_with_enum_values.
@@ -2468,12 +2471,13 @@ CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
 `</tt:cond>`.
     validate_output( act = act_output no_log_check = abap_true ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 117
-                                                                                    attr1 = `UTCLONG`
-                                                                                    attr2 = `STRUCTURE_DIFFERENT_DEFAULT-DATE_TIME_FIELD` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 117
+                                                                                           attr1 = `UTCLONG`
+                                                                                           attr2 = `STRUCTURE_DIFFERENT_DEFAULT-DATE_TIME_FIELD` )
+                                                             exp_component_name = `STRUCTURE_DIFFERENT_DEFAULT-DATE_TIME_FIELD`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD structure_with_default_problem.
@@ -2527,16 +2531,18 @@ CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
 `</tt:cond>`.
     validate_output( act = act_output no_log_check = abap_true ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 126
-                                                                                    attr1 = `STRUCTURE_WITH_DEFAULT_PROBLEM-INTEGER` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 126
-                                                                                    attr1 = `STRUCTURE_WITH_DEFAULT_PROBLEM-ENUM_REQUIRED` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 126
+                                                                                           attr1 = `STRUCTURE_WITH_DEFAULT_PROBLEM-INTEGER` )
+                                                             exp_component_name = `STRUCTURE_WITH_DEFAULT_PROBLEM-INTEGER`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 126
+                                                                                           attr1 = `STRUCTURE_WITH_DEFAULT_PROBLEM-ENUM_REQUIRED` )
+                                                             exp_component_name = `STRUCTURE_WITH_DEFAULT_PROBLEM-ENUM_REQUIRED`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
 
   ENDMETHOD.
 
@@ -2659,12 +2665,13 @@ CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
 
     validate_output( act = act_output no_log_check = abap_true ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 122
-                                                                                    attr1 = `CO_TEST`
-                                                                                    attr2 = `STRUC_LINK_WRONG_TYPE-DEFAULT_LINK` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 122
+                                                                                           attr1 = `CO_TEST`
+                                                                                           attr2 = `STRUC_LINK_WRONG_TYPE-DEFAULT_LINK` )
+                                                             exp_component_name = `STRUC_LINK_WRONG_TYPE-DEFAULT_LINK`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD structure_with_wrong_default.
@@ -2706,19 +2713,21 @@ CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
 `</tt:cond>`.
     validate_output( act = act_output no_log_check = abap_true ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 105
-                                                                                    attr1 = `WRONG_COMPONENT`
-                                                                                    attr2 = `ENUM_VALUES`
-                                                                                    attr3 = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_ONE` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 111
-                                                                                    attr1 = `$default`
-                                                                                    attr2 = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_TWO` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 105
+                                                                                           attr1 = `WRONG_COMPONENT`
+                                                                                           attr2 = `ENUM_VALUES`
+                                                                                           attr3 = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_ONE` )
+                                                             exp_component_name = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_ONE`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 111
+                                                                                           attr1 = `$default`
+                                                                                           attr2 = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_TWO` )
+                                                             exp_component_name = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_TWO`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD simple_element_with_callack.
@@ -2919,17 +2928,19 @@ CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
 `</tt:cond>`.
     validate_output( act = act_output no_log_check = abap_true ).
     log = cut->zif_aff_writer~get_log( ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 106
-                                                                                    attr1 = `STRUCTURE_WITH_WRONG_CALLBACK-MY_FIRST_ELEMENT` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
-    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log         = log
-                                                             exp_message = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                    msgno = 109
-                                                                                    attr1 = `$callbackClass`
-                                                                                    attr2 = `STRUCTURE_WITH_WRONG_CALLBACK-MY_SECOND_ELEMENT` )
-                                                             exp_type    = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 106
+                                                                                           attr1 = `STRUCTURE_WITH_WRONG_CALLBACK-MY_FIRST_ELEMENT` )
+                                                             exp_component_name = `STRUCTURE_WITH_WRONG_CALLBACK-MY_FIRST_ELEMENT`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
+    zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
+                                                             exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
+                                                                                           msgno = 109
+                                                                                           attr1 = `$callbackClass`
+                                                                                           attr2 = `STRUCTURE_WITH_WRONG_CALLBACK-MY_SECOND_ELEMENT` )
+                                                             exp_component_name = `STRUCTURE_WITH_WRONG_CALLBACK-MY_SECOND_ELEMENT`
+                                                             exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
   METHOD validate_output.

--- a/src/zcl_aff_writer_xslt.clas.testclasses.abap
+++ b/src/zcl_aff_writer_xslt.clas.testclasses.abap
@@ -31,7 +31,7 @@ INTERFACE lif_test_types.
   TYPES:
     BEGIN OF include_in_include.
       INCLUDE TYPE include.
-TYPES END OF include_in_include.
+  TYPES END OF include_in_include.
 
   TYPES:
     BEGIN OF structure_include_in_include.

--- a/src/zif_aff_log.intf.abap
+++ b/src/zif_aff_log.intf.abap
@@ -12,12 +12,14 @@ INTERFACE zif_aff_log
   TYPES:
     "! A single message entry in the log
     BEGIN OF ty_log_out,
+      "! The name of the component for which the message was logged
+      component_name TYPE string,
       "! The type of the message
-      type    TYPE symsgty,
+      type           TYPE symsgty,
       "! The text of the message
-      text    TYPE string,
+      text           TYPE string,
       "! The message
-      message TYPE symsg,
+      message        TYPE symsg,
     END OF ty_log_out,
     tt_log_out TYPE STANDARD TABLE OF ty_log_out WITH NON-UNIQUE DEFAULT KEY.
 
@@ -25,29 +27,37 @@ INTERFACE zif_aff_log
     "! Adds an info message (type I) to the log.
     "!
     "! @parameter message | the message
+    "! @parameter component_name | the name of the element for which the log entry is created
     add_info
-      IMPORTING message TYPE symsg,
+      IMPORTING message        TYPE symsg
+                component_name TYPE string,
 
     "! Adds a warning message (type W) to the log.
     "!
     "! @parameter message | the message
+    "! @parameter component_name | the name of the element for which the log entry is created
     add_warning
-      IMPORTING message TYPE symsg,
+      IMPORTING message        TYPE symsg
+                component_name TYPE string,
 
     "! Adds an error message (type E) to the log.
     "!
     "! @parameter message | the message
+    "! @parameter component_name | the name of the element for which the log entry is created
     add_error
-      IMPORTING message TYPE symsg,
+      IMPORTING message        TYPE symsg
+                component_name TYPE string,
 
     "! Adds an exception to the log. Actually not the exception is added
     "! but the message of the exception. The message type can be submitted.
     "!
     "! @parameter exception | the exception containing the message
     "! @parameter message_type | the type of the message
+    "! @parameter component_name | the name of the element for which the log entry is created
     add_exception
-      IMPORTING exception    TYPE REF TO cx_root
-                message_type TYPE symsgty DEFAULT c_message_type-error,
+      IMPORTING exception      TYPE REF TO cx_root
+                message_type   TYPE symsgty DEFAULT c_message_type-error
+                component_name TYPE string,
 
     "! Returns the logged messages. The log is NOT cleared afterwards.
     "! The caller has to {@link METH.clear} it in case it should be reused.


### PR DESCRIPTION
This is the first step of a refactoring of logging.
I added the name of the component that caused the entry to the log.
Unit tests now also check if the right component is handed over.

In a second step, the message class will be adapted such that messages don't contain the name of the component.