### PR TITLE
Refactor log messages

### DIFF
--- a/src/zaff_tools.msag.xml
+++ b/src/zaff_tools.msag.xml
@@ -42,103 +42,103 @@
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>103</MSGNR>
-     <TEXT>Class/Interface &amp;1 for element &amp;2 given in ABAP Doc link doesn&apos;t exist</TEXT>
+     <TEXT>Class/Interface &amp;1 given in ABAP Doc link doesn&apos;t exist</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>104</MSGNR>
-     <TEXT>Constant &amp;1 for element &amp;2 given in ABAP Doc link doesn&apos;t exist</TEXT>
+     <TEXT>Constant &amp;1 given in ABAP Doc link doesn&apos;t exist</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>105</MSGNR>
-     <TEXT>Component &amp;1 of constant &amp;2 for element &amp;3 in ABAP Doc link doesn&apos;t exist</TEXT>
+     <TEXT>Component &amp;1 of constant &amp;2 in ABAP Doc link doesn&apos;t exist</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>106</MSGNR>
-     <TEXT>Invalid callback class of element &amp;1</TEXT>
+     <TEXT>Callback class is invalid</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>107</MSGNR>
-     <TEXT>Several occurrences of annotation &amp;1 for element &amp;2. First valid is used</TEXT>
+     <TEXT>There are several occurrences of annotation &amp;1. First valid is used</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>108</MSGNR>
-     <TEXT>Unknown annotation &amp;1 for element &amp;2</TEXT>
+     <TEXT>Annotation &amp;1 is unknown</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>109</MSGNR>
-     <TEXT>Wrong usage of annotation &amp;1 for element &amp;2</TEXT>
+     <TEXT>Annotation &amp;1  was used incorrectly</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>110</MSGNR>
-     <TEXT>No number provided for annotation &amp;1 for element &amp;2</TEXT>
+     <TEXT>No number was provided for annotation &amp;1</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>111</MSGNR>
-     <TEXT>Wrong link in annotation &amp;1 for element &amp;2</TEXT>
+     <TEXT>Link in annotation &amp;1 is incorrect</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>112</MSGNR>
-     <TEXT>For element &amp;1: If $$required is set, $$showAlways is redundant</TEXT>
+     <TEXT>If $$required is set, $$showAlways is redundant</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>113</MSGNR>
-     <TEXT>Title for element &amp;1 at wrong position</TEXT>
+     <TEXT>Title is at wrong position</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>114</MSGNR>
-     <TEXT>Invalid default argument of element &amp;1</TEXT>
+     <TEXT>Default argument is invalid</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>115</MSGNR>
-     <TEXT>Description for element &amp;1 at wrong position</TEXT>
+     <TEXT>Description is at wrong position</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>116</MSGNR>
-     <TEXT>Text between annotations for element &amp;1 will not be parsed</TEXT>
+     <TEXT>Text between annotations will not be parsed</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>117</MSGNR>
-     <TEXT>Annotation $$default for type &amp;1 of element &amp;2 is not supported</TEXT>
+     <TEXT>Annotation $$default for type &amp;1 is not supported</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>118</MSGNR>
-     <TEXT>Annotation &amp;1 for element &amp;2 is not allowed</TEXT>
+     <TEXT>Annotation &amp;1 is not allowed</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>119</MSGNR>
-     <TEXT>&amp;1 is missing for element &amp;2</TEXT>
+     <TEXT>&amp;1 is missing</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
@@ -162,7 +162,7 @@
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>123</MSGNR>
-     <TEXT>No structure provided for type generator</TEXT>
+     <TEXT>No structure was provided for type generator</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
@@ -174,19 +174,19 @@
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>125</MSGNR>
-     <TEXT>Description for element &amp;1 exceeds &amp;2 characters and might be too long</TEXT>
+     <TEXT>Description exceeds &amp;2 characters and might be too long</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>126</MSGNR>
-     <TEXT>For element &amp;1: For required fields, a default handling is not possible</TEXT>
+     <TEXT>For required fields, a default handling is not possible</TEXT>
     </T100>
     <T100>
      <SPRSL>E</SPRSL>
      <ARBGB>ZAFF_TOOLS</ARBGB>
      <MSGNR>127</MSGNR>
-     <TEXT>Element &amp;1 of type enum should be required or have a default</TEXT>
+     <TEXT>Elements of type enum should be required or have a default</TEXT>
     </T100>
    </T100>
   </asx:values>

--- a/src/zcl_aff_abap_doc_parser.clas.abap
+++ b/src/zcl_aff_abap_doc_parser.clas.abap
@@ -122,12 +122,12 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
     IF lines( result_table ) = 0.
       RETURN.
     ELSEIF lines( result_table ) > 1.
-      MESSAGE i107(zaff_tools) WITH `'Title'` component_name INTO DATA(message) ##NEEDED.
+      MESSAGE i107(zaff_tools) WITH `'Title'` INTO DATA(message) ##NEEDED.
       parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
     DATA(offset) = result_table[ 1 ]-offset.
     IF offset <> 0.
-      MESSAGE i113(zaff_tools) WITH component_name INTO message ##NEEDED.
+      MESSAGE i113(zaff_tools) INTO message ##NEEDED.
       parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
     DATA(length) = result_table[ 1 ]-length.
@@ -177,7 +177,7 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
           parse_number_annotations( key_word = key_word ).
         WHEN OTHERS.
           REPLACE key_word IN modified_abap_doc_string WITH ''.
-          MESSAGE w108(zaff_tools) WITH key_word component_name INTO DATA(message) ##NEEDED.
+          MESSAGE w108(zaff_tools) WITH key_word INTO DATA(message) ##NEEDED.
           parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
       ENDCASE.
     ENDLOOP.
@@ -192,12 +192,12 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
     REPLACE ALL OCCURRENCES OF PCRE `\$callbackClass[\s]*(:[\s]*)?\{[\s]*@link` IN string_to_parse WITH `\$callbackClass\{@link`.
     FIND ALL OCCURRENCES OF PCRE `\$callbackClass\{@link[^\}]+\}` IN string_to_parse RESULTS DATA(result_table).
     IF lines( result_table ) = 0.
-      MESSAGE w109(zaff_tools) WITH abap_doc_annotation-callback_class component_name INTO DATA(message) ##NEEDED.
+      MESSAGE w109(zaff_tools) WITH abap_doc_annotation-callback_class INTO DATA(message) ##NEEDED.
       parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
       RETURN.
     ENDIF.
     IF lines( result_table ) > 1.
-      MESSAGE i107(zaff_tools) WITH abap_doc_annotation-callback_class component_name INTO message ##NEEDED.
+      MESSAGE i107(zaff_tools) WITH abap_doc_annotation-callback_class INTO message ##NEEDED.
       parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
     DATA(offset_found) = result_table[ 1 ]-offset.
@@ -239,12 +239,12 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
     ENDLOOP.
 
     IF lines( mixed_result_table ) = 0.
-      MESSAGE w109(zaff_tools) WITH abap_doc_annotation-default component_name INTO DATA(message) ##NEEDED.
+      MESSAGE w109(zaff_tools) WITH abap_doc_annotation-default INTO DATA(message) ##NEEDED.
       parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
       RETURN.
     ENDIF.
     IF lines( mixed_result_table ) > 1.
-      MESSAGE i107(zaff_tools) WITH abap_doc_annotation-default component_name INTO message ##NEEDED.
+      MESSAGE i107(zaff_tools) WITH abap_doc_annotation-default INTO message ##NEEDED.
       parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
     DATA(warning_set) = abap_false.
@@ -261,7 +261,7 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
         IF lines( splitted ) = 3.
           decoded_abap_doc-default = link.
         ELSEIF warning_set = abap_false.
-          MESSAGE w111(zaff_tools) WITH abap_doc_annotation-default component_name INTO message ##NEEDED.
+          MESSAGE w111(zaff_tools) WITH abap_doc_annotation-default INTO message ##NEEDED.
           parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
           warning_set = abap_true.
         ENDIF.
@@ -279,12 +279,12 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
     REPLACE ALL OCCURRENCES OF PCRE `\$values[\s]*(:[\s]*)?\{[\s]*@link` IN string_to_parse WITH `\$values\{@link`.
     FIND ALL OCCURRENCES OF PCRE `\$values\{@link([^\}]+)\}` IN string_to_parse RESULTS DATA(result_table).
     IF lines( result_table ) = 0.
-      MESSAGE w109(zaff_tools) WITH abap_doc_annotation-values component_name INTO DATA(message) ##NEEDED.
+      MESSAGE w109(zaff_tools) WITH abap_doc_annotation-values INTO DATA(message) ##NEEDED.
       parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
       RETURN.
     ENDIF.
     IF lines( result_table ) > 1.
-      MESSAGE i107(zaff_tools) WITH abap_doc_annotation-values component_name INTO message ##NEEDED.
+      MESSAGE i107(zaff_tools) WITH abap_doc_annotation-values INTO message ##NEEDED.
       parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
     DATA(warning_written) = abap_false.
@@ -300,7 +300,7 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
       IF lines( splitted ) = 2 AND decoded_abap_doc-enumvalues_link IS INITIAL.
         decoded_abap_doc-enumvalues_link = link.
       ELSEIF lines( splitted ) <> 2 AND warning_written = abap_false.
-        MESSAGE w111(zaff_tools) WITH abap_doc_annotation-values component_name INTO message ##NEEDED.
+        MESSAGE w111(zaff_tools) WITH abap_doc_annotation-values INTO message ##NEEDED.
         parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
         warning_written = abap_true.
       ENDIF.
@@ -314,7 +314,7 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
     ENDIF.
     FIND ALL OCCURRENCES OF abap_doc_annotation-required IN abap_doc_string RESULTS DATA(result_table).
     IF lines( result_table ) > 1.
-      MESSAGE i107(zaff_tools) WITH abap_doc_annotation-required component_name INTO DATA(message) ##NEEDED.
+      MESSAGE i107(zaff_tools) WITH abap_doc_annotation-required INTO DATA(message) ##NEEDED.
       parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
     decoded_abap_doc-required = abap_true.
@@ -330,7 +330,7 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
     ENDIF.
     FIND ALL OCCURRENCES OF abap_doc_annotation-show_always IN abap_doc_string RESULTS DATA(result_table).
     IF lines( result_table ) > 1.
-      MESSAGE i107(zaff_tools) WITH abap_doc_annotation-show_always component_name INTO DATA(message) ##NEEDED.
+      MESSAGE i107(zaff_tools) WITH abap_doc_annotation-show_always INTO DATA(message) ##NEEDED.
       parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
     decoded_abap_doc-showalways = abap_true.
@@ -381,12 +381,12 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
     REPLACE ALL OCCURRENCES OF PCRE `\$dummyannotation[\s]*(:[\s]*)?` IN abap_doc WITH `\$dummyannotation`.
     FIND ALL OCCURRENCES OF PCRE `\$dummyannotation[^\s]+` IN abap_doc RESULTS DATA(result_table).
     IF lines( result_table ) = 0.
-      MESSAGE w109(zaff_tools) WITH abap_doc_annotation-values component_name INTO DATA(message) ##NEEDED.
+      MESSAGE w109(zaff_tools) WITH abap_doc_annotation-values INTO DATA(message) ##NEEDED.
       parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
       RETURN.
     ENDIF.
     IF lines( result_table ) > 1.
-      MESSAGE i107(zaff_tools) WITH annotation_name component_name INTO message ##NEEDED.
+      MESSAGE i107(zaff_tools) WITH annotation_name INTO message ##NEEDED.
       parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
     DATA(annotation_length) = strlen( dummy_annotation ).
@@ -406,7 +406,7 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
       IF match = abap_true AND number IS INITIAL.
         number = number_candidate.
       ELSEIF match = abap_false AND warning_written = abap_false.
-        MESSAGE w110(zaff_tools) WITH annotation_name component_name INTO message ##NEEDED.
+        MESSAGE w110(zaff_tools) WITH annotation_name INTO message ##NEEDED.
         parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
         warning_written = abap_true.
       ENDIF.
@@ -454,10 +454,10 @@ CLASS zcl_aff_abap_doc_parser IMPLEMENTATION.
 
   METHOD write_description_message.
     IF description_warning_is_needed = abap_true AND decoded_abap_doc-description IS INITIAL.
-      MESSAGE w115(zaff_tools) WITH component_name INTO DATA(message) ##NEEDED.
+      MESSAGE w115(zaff_tools) INTO DATA(message) ##NEEDED.
       parser_log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ELSEIF description_warning_is_needed = abap_true AND decoded_abap_doc-description IS NOT INITIAL.
-      MESSAGE i116(zaff_tools) WITH component_name INTO message ##NEEDED.
+      MESSAGE i116(zaff_tools) INTO message ##NEEDED.
       parser_log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
   ENDMETHOD.

--- a/src/zcl_aff_abap_doc_parser.clas.testclasses.abap
+++ b/src/zcl_aff_abap_doc_parser.clas.testclasses.abap
@@ -161,16 +161,14 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 107
-                                                                                           attr1 = `'Title'`
-                                                                                           attr2 = `Component Name` )
+                                                                                           attr1 = `'Title'` )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
 
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 107
-                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-show_always
-                                                                                           attr2 = `Component Name` )
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-show_always )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
@@ -189,15 +187,13 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 107
-                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-minimum
-                                                                                           attr2 = `Component Name` )
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-minimum )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 107
-                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-maximum
-                                                                                           attr2 = `Component Name` )
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-maximum )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
@@ -216,8 +212,7 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 107
-                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
-                                                                                           attr2 = `Component Name` )
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
@@ -236,8 +231,7 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 107
-                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
-                                                                                           attr2 = `Component Name` )
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
@@ -256,8 +250,7 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 107
-                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
-                                                                                           attr2 = `Component Name` )
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
@@ -276,8 +269,7 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 107
-                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-values
-                                                                                           attr2 = `Component Name` )
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-values )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
@@ -296,8 +288,7 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 107
-                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-callback_class
-                                                                                           attr2 = `Component Name` )
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-callback_class )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
@@ -316,8 +307,7 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 107
-                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-required
-                                                                                           attr2 = `Component Name` )
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-required )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
@@ -336,8 +326,7 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 108
-                                                                                           attr1 = `$unknown`
-                                                                                           attr2 = `Component Name` )
+                                                                                           attr1 = `$unknown` )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
@@ -356,8 +345,7 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 109
-                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-callback_class
-                                                                                           attr2 = `Component Name` )
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-callback_class )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
@@ -388,15 +376,13 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 109
-                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
-                                                                                           attr2 = `Component Name1` )
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default )
                                                              exp_component_name = `Component Name1`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 109
-                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
-                                                                                           attr2 = `Component Name2` )
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default )
                                                              exp_component_name = `Component Name2`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
@@ -415,8 +401,7 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 109
-                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-values
-                                                                                           attr2 = `Component Name` )
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-values )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
@@ -435,15 +420,13 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 110
-                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-minimum
-                                                                                           attr2 = `Component Name` )
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-minimum )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 110
-                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-maximum
-                                                                                           attr2 = `Component Name` )
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-maximum )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
@@ -462,15 +445,13 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 111
-                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-values
-                                                                                           attr2 = `Component Name` )
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-values )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 111
-                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default
-                                                                                           attr2 = `Component Name` )
+                                                                                           attr1 = zcl_aff_abap_doc_parser=>abap_doc_annotation-default )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
@@ -488,8 +469,7 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                           msgno = 115
-                                                                                           attr1 = `Component Name` )
+                                                                                           msgno = 115 )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
@@ -507,8 +487,7 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                           msgno = 116
-                                                                                           attr1 = `Component Name` )
+                                                                                           msgno = 116 )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
@@ -526,14 +505,12 @@ CLASS ltcl_aff_abap_doc_parser IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( exp = exp_abap_doc act = act_abap_doc ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                           msgno = 116
-                                                                                           attr1 = `Component Name` )
+                                                                                           msgno = 116 )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                           msgno = 113
-                                                                                           attr1 = `Component Name` )
+                                                                                           msgno = 113 )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.

--- a/src/zcl_aff_writer.clas.abap
+++ b/src/zcl_aff_writer.clas.abap
@@ -529,7 +529,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
         OTHERS        = 3.
     IF sy-subrc <> 0.
 *    class or interface doesn't exist
-      MESSAGE w103(zaff_tools) WITH name_of_source fullname_of_type INTO DATA(message) ##NEEDED.
+      MESSAGE w103(zaff_tools) WITH name_of_source INTO DATA(message) ##NEEDED.
       log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
     ELSE.
       DATA(constant_descr) = cl_abap_typedescr=>describe_by_name( name_of_source ).
@@ -547,7 +547,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
         ).
         IF sy-subrc <> 0.
 *      constant in interface does not exist
-          MESSAGE w104(zaff_tools) WITH name_of_source && '=>' && name_of_constant fullname_of_type INTO message ##NEEDED.
+          MESSAGE w104(zaff_tools) WITH name_of_source && '=>' && name_of_constant INTO message ##NEEDED.
           log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
         ENDIF.
       ELSEIF clstype = seoc_clstype_class.
@@ -563,7 +563,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
         ).
         IF sy-subrc <> 0.
 *      constant in class does not exits
-          MESSAGE w104(zaff_tools) WITH name_of_source && '=>' && name_of_constant fullname_of_type INTO message ##NEEDED.
+          MESSAGE w104(zaff_tools) WITH name_of_source && '=>' && name_of_constant INTO message ##NEEDED.
           log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
         ENDIF.
       ENDIF.
@@ -652,7 +652,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
       is_valid = xsdbool( get_subschema_exists = abap_true AND serialize_exists = abap_true AND deserialize_exists = abap_true ).
     ENDIF.
     IF is_valid = abap_false.
-      MESSAGE w106(zaff_tools) WITH component_name INTO DATA(message) ##NEEDED.
+      MESSAGE w106(zaff_tools) INTO DATA(message) ##NEEDED.
       log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = component_name ).
     ENDIF.
   ENDMETHOD.
@@ -678,7 +678,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
             log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
           ENDIF.
         ELSE.
-          MESSAGE w105(zaff_tools) WITH component_name constant_name fullname_of_type INTO message ##NEEDED.
+          MESSAGE w105(zaff_tools) WITH component_name constant_name INTO message ##NEEDED.
           log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
         ENDIF.
       ENDIF.
@@ -696,7 +696,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
     ASSIGN r_field->* TO <field>.
     IF element_description->type_kind = cl_abap_typedescr=>typekind_utclong.
 *      No support for default with utclong
-      MESSAGE w117(zaff_tools) WITH 'UTCLONG'  fullname_of_type INTO DATA(message) ##NEEDED.
+      MESSAGE w117(zaff_tools) WITH 'UTCLONG' INTO DATA(message) ##NEEDED.
       log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
       is_valid = abap_false.
       RETURN.
@@ -742,7 +742,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
       ENDTRY.
     ENDIF.
     IF is_valid = abap_false.
-      MESSAGE w114(zaff_tools) WITH fullname_of_type INTO message ##NEEDED.
+      MESSAGE w114(zaff_tools) INTO message ##NEEDED.
       log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
     ENDIF.
   ENDMETHOD.
@@ -775,12 +775,12 @@ CLASS zcl_aff_writer IMPLEMENTATION.
 
   METHOD check_redundant_annotations.
     IF abap_doc-showalways = abap_true AND abap_doc-required = abap_true.
-      MESSAGE i112(zaff_tools) WITH fullname_of_type INTO DATA(message) ##NEEDED.
+      MESSAGE i112(zaff_tools) INTO DATA(message) ##NEEDED.
       log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
     ENDIF.
 
     IF abap_doc-required = abap_true AND abap_doc-default IS NOT INITIAL.
-      MESSAGE w126(zaff_tools) WITH fullname_of_type INTO message ##NEEDED.
+      MESSAGE w126(zaff_tools) INTO message ##NEEDED.
       log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
     ENDIF.
   ENDMETHOD.

--- a/src/zcl_aff_writer.clas.testclasses.abap
+++ b/src/zcl_aff_writer.clas.testclasses.abap
@@ -401,8 +401,7 @@ CLASS ltcl_type_writer IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( exp = abap_false act = is_valid ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                           msgno = 106
-                                                                                           attr1 = `Component Name` )
+                                                                                           msgno = 106 )
                                                              exp_component_name = `Component Name`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.

--- a/src/zcl_aff_writer_json_schema.clas.abap
+++ b/src/zcl_aff_writer_json_schema.clas.abap
@@ -871,7 +871,7 @@ CLASS zcl_aff_writer_json_schema IMPLEMENTATION.
         check_title_and_description( abap_doc_to_check = abap_doc_of_component fullname_of_checked_type = fullname_of_value ).
       ENDLOOP.
       IF has_initial_component = abap_false AND abap_doc-required = abap_false AND abap_doc-default IS INITIAL.
-        MESSAGE w127(zaff_tools) WITH fullname_of_type INTO DATA(message) ##NEEDED ##NO_TEXT.
+        MESSAGE w127(zaff_tools) INTO DATA(message) ##NEEDED ##NO_TEXT.
         log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
       ENDIF.
     ENDIF.
@@ -967,15 +967,15 @@ CLASS zcl_aff_writer_json_schema IMPLEMENTATION.
   METHOD check_title_and_description.
     IF ignore_til_indent_level IS INITIAL OR ignore_til_indent_level > indent_level. "Only write message if no callback class provided
       IF abap_doc_to_check-title IS INITIAL.
-        MESSAGE i119(zaff_tools) WITH 'Title' fullname_of_checked_type INTO DATA(message) ##NEEDED ##NO_TEXT.
+        MESSAGE i119(zaff_tools) WITH 'Title' INTO DATA(message) ##NEEDED ##NO_TEXT.
         log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_checked_type ).
       ENDIF.
 
       IF abap_doc_to_check-description IS INITIAL.
-        MESSAGE i119(zaff_tools) WITH 'Description' fullname_of_checked_type INTO message ##NEEDED ##NO_TEXT.
+        MESSAGE i119(zaff_tools) WITH 'Description' INTO message ##NEEDED ##NO_TEXT.
         log->add_info( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_checked_type  ).
       ELSEIF strlen( abap_doc_to_check-description ) > c_max_length_of_description.
-        MESSAGE w125(zaff_tools) WITH fullname_of_checked_type c_max_length_of_description INTO message ##NEEDED ##NO_TEXT.
+        MESSAGE w125(zaff_tools) WITH c_max_length_of_description INTO message ##NEEDED ##NO_TEXT.
         log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_checked_type ).
       ENDIF.
     ENDIF.

--- a/src/zcl_aff_writer_json_schema.clas.testclasses.abap
+++ b/src/zcl_aff_writer_json_schema.clas.testclasses.abap
@@ -613,8 +613,7 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 108
-                                                                                           attr1 = `$hiddenabc`
-                                                                                           attr2 = `UNKNOWN_ANNOTATION` )
+                                                                                           attr1 = `$hiddenabc` )
                                                              exp_component_name = `UNKNOWN_ANNOTATION`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
@@ -818,8 +817,7 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 108
-                                                                                           attr1 = `$ructure`
-                                                                                           attr2 = `MY_STRUCTURE2` )
+                                                                                           attr1 = `$ructure` )
                                                              exp_component_name = `MY_STRUCTURE2`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
@@ -1009,8 +1007,7 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
     log = cut->zif_aff_writer~get_log( ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                           msgno = 127
-                                                                                           attr1 = `STRUCTURE_WITH_DIFFERENT_ENUM-ENUM_WITHOUT_ALL` )
+                                                                                           msgno = 127 )
                                                              exp_component_name = `STRUCTURE_WITH_DIFFERENT_ENUM-ENUM_WITHOUT_ALL`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
@@ -1302,8 +1299,7 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 104
-                                                                                           attr1 = `ZCL_AFF_TEST_TYPES=>ENUM_VALUES_WRONG`
-                                                                                           attr2 = `STRUCTURE_WITH_WRONG_LINK-ELEMENT_TWO` )
+                                                                                           attr1 = `ZCL_AFF_TEST_TYPES=>ENUM_VALUES_WRONG` )
                                                              exp_component_name = `STRUCTURE_WITH_WRONG_LINK-ELEMENT_TWO`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
@@ -1651,8 +1647,7 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 117
-                                                                                           attr1 = `UTCLONG`
-                                                                                           attr2 = `STRUCTURE_DIFFERENT_DEFAULT-DATE_TIME_FIELD` )
+                                                                                           attr1 = `UTCLONG` )
                                                              exp_component_name = `STRUCTURE_DIFFERENT_DEFAULT-DATE_TIME_FIELD`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
@@ -1730,14 +1725,12 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_equals_ignore_spaces( act_data = act_schema_co exp_data = exp_schema ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                           msgno = 126
-                                                                                           attr1 = `STRUCTURE_WITH_DEFAULT_PROBLEM-INTEGER` )
+                                                                                           msgno = 126 )
                                                              exp_component_name = `STRUCTURE_WITH_DEFAULT_PROBLEM-INTEGER`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                           msgno = 126
-                                                                                           attr1 = `STRUCTURE_WITH_DEFAULT_PROBLEM-ENUM_REQUIRED` )
+                                                                                           msgno = 126 )
                                                              exp_component_name = `STRUCTURE_WITH_DEFAULT_PROBLEM-ENUM_REQUIRED`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
 
@@ -1858,22 +1851,19 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 105
                                                                                            attr1 = `WRONG_COMPONENT`
-                                                                                           attr2 = `ENUM_VALUES`
-                                                                                           attr3 = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_ONE` )
+                                                                                           attr2 = `ENUM_VALUES` )
                                                              exp_component_name = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_ONE`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 111
-                                                                                           attr1 = cl_aff_abap_doc_parser=>abap_doc_annotation-default
-                                                                                           attr2 = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_TWO` )
+                                                                                           attr1 = cl_aff_abap_doc_parser=>abap_doc_annotation-default )
                                                              exp_component_name = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_TWO`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 119
-                                                                                           attr1 = `Title`
-                                                                                           attr2 = `ENUM_VALUES-CLASSIC_BADI` )
+                                                                                           attr1 = `Title` )
                                                              exp_component_name = `ENUM_VALUES-CLASSIC_BADI`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
@@ -2294,15 +2284,13 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
     log = cut->zif_aff_writer~get_log( ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                           msgno = 106
-                                                                                           attr1 = `STRUCTURE_WITH_WRONG_CALLBACK-MY_FIRST_ELEMENT` )
+                                                                                           msgno = 106 )
                                                              exp_component_name = `STRUCTURE_WITH_WRONG_CALLBACK-MY_FIRST_ELEMENT`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 109
-                                                                                           attr1 = cl_aff_abap_doc_parser=>abap_doc_annotation-callback_class
-                                                                                           attr2 = `STRUCTURE_WITH_WRONG_CALLBACK-MY_SECOND_ELEMENT` )
+                                                                                           attr1 = cl_aff_abap_doc_parser=>abap_doc_annotation-callback_class )
                                                              exp_component_name = `STRUCTURE_WITH_WRONG_CALLBACK-MY_SECOND_ELEMENT`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
@@ -2349,43 +2337,37 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 119
-                                                                                           attr1 = `Title`
-                                                                                           attr2 = `STRUCTURE_NO_TITLE_DESCR` )
+                                                                                           attr1 = `Title` )
                                                              exp_component_name = `STRUCTURE_NO_TITLE_DESCR`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 119
-                                                                                           attr1 = `Description`
-                                                                                           attr2 = `STRUCTURE_NO_TITLE_DESCR` )
+                                                                                           attr1 = `Description` )
                                                              exp_component_name = `STRUCTURE_NO_TITLE_DESCR`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 119
-                                                                                           attr1 = `Title`
-                                                                                           attr2 = `STRUCTURE_NO_TITLE_DESCR-FIELD1` )
+                                                                                           attr1 = `Title` )
                                                              exp_component_name = `STRUCTURE_NO_TITLE_DESCR-FIELD1`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 119
-                                                                                           attr1 = `Description`
-                                                                                           attr2 = `STRUCTURE_NO_TITLE_DESCR-INNER_STRUC` )
+                                                                                           attr1 = `Description` )
                                                              exp_component_name = `STRUCTURE_NO_TITLE_DESCR-INNER_STRUC`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                                msgno = 119
-                                                                                               attr1 = `Title`
-                                                                                               attr2 = `STRUCTURE_NO_TITLE_DESCR-INNER_TABLE` )
+                                                                                               attr1 = `Title` )
                                                              exp_component_name = `STRUCTURE_NO_TITLE_DESCR-INNER_TABLE`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 119
-                                                                                           attr1 = `Description`
-                                                                                           attr2 = `STRUCTURE_NO_TITLE_DESCR-INNER_TABLE` )
+                                                                                           attr1 = `Description` )
                                                              exp_component_name = `STRUCTURE_NO_TITLE_DESCR-INNER_TABLE`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
@@ -2405,15 +2387,13 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 119
-                                                                                           attr1 = `Title`
-                                                                                           attr2 = `ELEMENT_NO_TITLE_DESCR` )
+                                                                                           attr1 = `Title` )
                                                              exp_component_name = `ELEMENT_NO_TITLE_DESCR`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 119
-                                                                                           attr1 = `Description`
-                                                                                           attr2 = `ELEMENT_NO_TITLE_DESCR` )
+                                                                                           attr1 = `Description` )
                                                              exp_component_name = `ELEMENT_NO_TITLE_DESCR`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
@@ -2436,15 +2416,13 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 119
-                                                                                           attr1 = `Title`
-                                                                                           attr2 = `TABLE_NO_TITLE_DESCR` )
+                                                                                           attr1 = `Title` )
                                                              exp_component_name = `TABLE_NO_TITLE_DESCR`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 119
-                                                                                           attr1 = `Description`
-                                                                                           attr2 = `TABLE_NO_TITLE_DESCR` )
+                                                                                           attr1 = `Description` )
                                                              exp_component_name = `TABLE_NO_TITLE_DESCR`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
   ENDMETHOD.
@@ -2533,15 +2511,13 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 119
-                                                                                           attr1 = `Title`
-                                                                                           attr2 = `STRUCTURE_WITH_INCLUDE-OTHER_ELEMENT` )
+                                                                                           attr1 = `Title` )
                                                              exp_component_name = `STRUCTURE_WITH_INCLUDE-OTHER_ELEMENT`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 119
-                                                                                           attr1 = `Description`
-                                                                                           attr2 = `TY_INCLUDE_TYPE-FIRST_ELEMENT` )
+                                                                                           attr1 = `Description` )
                                                              exp_component_name = `TY_INCLUDE_TYPE-FIRST_ELEMENT`
                                                              exp_type           = zif_aff_log=>c_message_type-info ).
 
@@ -2553,8 +2529,7 @@ CLASS ltcl_json_writer_abap_doc IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 125
-                                                                                           attr1 = `TYPE_WITH_LONG_DESCRIPTION`
-                                                                                           attr2 = zcl_aff_writer_json_schema=>c_max_length_of_description )
+                                                                                           attr1 = zcl_aff_writer_json_schema=>c_max_length_of_description )
                                                              exp_component_name = `TYPE_WITH_LONG_DESCRIPTION`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.

--- a/src/zcl_aff_writer_xslt.clas.abap
+++ b/src/zcl_aff_writer_xslt.clas.abap
@@ -544,7 +544,7 @@ CLASS zcl_aff_writer_xslt IMPLEMENTATION.
         ENDIF.
       ENDLOOP.
       IF has_initial_component = abap_false AND abap_doc-required = abap_false AND abap_doc-default IS INITIAL.
-        MESSAGE w127(zaff_tools) WITH fullname_of_type INTO DATA(message) ##NEEDED ##NO_TEXT.
+        MESSAGE w127(zaff_tools) INTO DATA(message) ##NEEDED ##NO_TEXT.
         log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
       ENDIF.
     ENDIF.
@@ -560,7 +560,7 @@ CLASS zcl_aff_writer_xslt IMPLEMENTATION.
 
   METHOD get_default_value_from_default.
     IF element_description->type_kind = cl_abap_typedescr=>typekind_utclong.
-      MESSAGE w117(zaff_tools) WITH 'UTCLONG'  fullname_of_type INTO DATA(message) ##NEEDED.
+      MESSAGE w117(zaff_tools) WITH 'UTCLONG' INTO DATA(message) ##NEEDED.
       log->add_warning( message = zcl_aff_log=>get_sy_message( ) component_name = fullname_of_type ).
       RETURN.
     ENDIF.
@@ -624,7 +624,7 @@ CLASS zcl_aff_writer_xslt IMPLEMENTATION.
       WHEN cl_abap_typedescr=>typekind_time.
         result = |T('{ value }')|.
       WHEN cl_abap_typedescr=>typekind_utclong.
-        RAISE EXCEPTION TYPE zcx_aff_tools MESSAGE e117(zaff_tools) WITH `UTCLONG` fullname_of_type.
+        RAISE EXCEPTION TYPE zcx_aff_tools MESSAGE e117(zaff_tools) WITH `UTCLONG`.
       WHEN OTHERS.
         RAISE EXCEPTION TYPE zcx_aff_tools MESSAGE e100(zaff_tools) WITH element_description->type_kind.
     ENDCASE.

--- a/src/zcl_aff_writer_xslt.clas.testclasses.abap
+++ b/src/zcl_aff_writer_xslt.clas.testclasses.abap
@@ -1845,8 +1845,7 @@ CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 108
-                                                                                           attr1 = `$ructure`
-                                                                                           attr2 = `MY_STRUCTURE2` )
+                                                                                           attr1 = `$ructure` )
                                                              exp_component_name = `MY_STRUCTURE2`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
@@ -1947,8 +1946,7 @@ CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
     DATA(log) = cut->zif_aff_writer~get_log( ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                           msgno = 127
-                                                                                           attr1 = `STRUCTURE_WITH_DIFFERENT_ENUM-ENUM_WITHOUT_ALL` )
+                                                                                           msgno = 127 )
                                                              exp_component_name = `STRUCTURE_WITH_DIFFERENT_ENUM-ENUM_WITHOUT_ALL`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
 
@@ -1992,8 +1990,7 @@ CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 104
-                                                                                           attr1 = `ZCL_AFF_TEST_TYPES=>ENUM_VALUES_WRONG`
-                                                                                           attr2 = `STRUCTURE_WITH_WRONG_LINK-ELEMENT_TWO` )
+                                                                                           attr1 = `ZCL_AFF_TEST_TYPES=>ENUM_VALUES_WRONG` )
                                                              exp_component_name = `STRUCTURE_WITH_WRONG_LINK-ELEMENT_TWO`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
@@ -2474,8 +2471,7 @@ CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 117
-                                                                                           attr1 = `UTCLONG`
-                                                                                           attr2 = `STRUCTURE_DIFFERENT_DEFAULT-DATE_TIME_FIELD` )
+                                                                                           attr1 = `UTCLONG` )
                                                              exp_component_name = `STRUCTURE_DIFFERENT_DEFAULT-DATE_TIME_FIELD`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
@@ -2533,14 +2529,12 @@ CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
     log = cut->zif_aff_writer~get_log( ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                           msgno = 126
-                                                                                           attr1 = `STRUCTURE_WITH_DEFAULT_PROBLEM-INTEGER` )
+                                                                                           msgno = 126 )
                                                              exp_component_name = `STRUCTURE_WITH_DEFAULT_PROBLEM-INTEGER`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                           msgno = 126
-                                                                                           attr1 = `STRUCTURE_WITH_DEFAULT_PROBLEM-ENUM_REQUIRED` )
+                                                                                           msgno = 126 )
                                                              exp_component_name = `STRUCTURE_WITH_DEFAULT_PROBLEM-ENUM_REQUIRED`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
 
@@ -2717,15 +2711,13 @@ CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 105
                                                                                            attr1 = `WRONG_COMPONENT`
-                                                                                           attr2 = `ENUM_VALUES`
-                                                                                           attr3 = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_ONE` )
+                                                                                           attr2 = `ENUM_VALUES` )
                                                              exp_component_name = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_ONE`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 111
-                                                                                           attr1 = `$default`
-                                                                                           attr2 = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_TWO` )
+                                                                                           attr1 = `$default` )
                                                              exp_component_name = `STRUCTURE_WITH_WRONG_DEFAULT-ELEMENT_TWO`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
@@ -2930,15 +2922,13 @@ CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
     log = cut->zif_aff_writer~get_log( ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
-                                                                                           msgno = 106
-                                                                                           attr1 = `STRUCTURE_WITH_WRONG_CALLBACK-MY_FIRST_ELEMENT` )
+                                                                                           msgno = 106 )
                                                              exp_component_name = `STRUCTURE_WITH_WRONG_CALLBACK-MY_FIRST_ELEMENT`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_msg( log                = log
                                                              exp_message        = VALUE #( msgid = 'ZAFF_TOOLS'
                                                                                            msgno = 109
-                                                                                           attr1 = `$callbackClass`
-                                                                                           attr2 = `STRUCTURE_WITH_WRONG_CALLBACK-MY_SECOND_ELEMENT` )
+                                                                                           attr1 = `$callbackClass` )
                                                              exp_component_name = `STRUCTURE_WITH_WRONG_CALLBACK-MY_SECOND_ELEMENT`
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.


### PR DESCRIPTION
This is the second step of refactoring logging.
Here, the log messages are rewritten so that they don't contain the name of the component that caused the entry anymore