### PR TITLE
Compatibility: Replace PCRE regex by POSIX regex

### DIFF
--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -15,7 +15,7 @@
     }
   ],
   "syntax": {
-    "version": "v755",
+    "version": "v754",
     "errorNamespace": "^(Z|Y|LCL_|TY_|LIF_)",
     "globalConstants": ["seoc_clstype_interface", "seoc_clstype_class", "srext_ext_xslt_source"]
   },

--- a/src/zcl_aff_writer.clas.abap
+++ b/src/zcl_aff_writer.clas.abap
@@ -574,7 +574,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
 
   METHOD get_infos_of_values_link.
     DATA(link) = values_link.
-    REPLACE ALL OCCURRENCES OF PCRE `[\s]` IN link WITH ``.
+    REPLACE ALL OCCURRENCES OF regex `[\s]` IN link WITH `` ##REGEX_POSIX.
     REPLACE ALL OCCURRENCES OF `data:` IN link WITH ``.
     SPLIT link AT '.' INTO TABLE DATA(split_at_point).
     IF lines( split_at_point ) = 2.
@@ -629,8 +629,8 @@ CLASS zcl_aff_writer IMPLEMENTATION.
 
   METHOD get_default_from_link.
     DATA(link_to_work_on) = link.
-    REPLACE ALL OCCURRENCES OF PCRE `(@link|data:)` IN link_to_work_on WITH ``.
-    REPLACE ALL OCCURRENCES OF PCRE `[\s]` IN link_to_work_on WITH ``.
+    REPLACE ALL OCCURRENCES OF regex `(@link|data:)` IN link_to_work_on WITH `` ##REGEX_POSIX.
+    REPLACE ALL OCCURRENCES OF regex `[\s]` IN link_to_work_on WITH `` ##REGEX_POSIX.
     SPLIT link_to_work_on AT '.' INTO TABLE DATA(splitted).
     IF validate_default_link( splitted_link = splitted fullname_of_type = fullname_of_type element_type = element_type ) = abap_true.
       DATA(default_abap) = splitted[ lines( splitted ) ].
@@ -717,7 +717,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
             default = default && repeat( val = '0' occ = 6 - strlen( default ) ).
           ENDIF.
           IF element_description->type_kind = cl_abap_typedescr=>typekind_utclong.
-            REPLACE PCRE `T|t` IN default WITH ` `.
+            REPLACE regex `T|t` IN default WITH ` ` ##REGEX_POSIX.
           ENDIF.
           remove_leading_trailing_spaces( CHANGING string_to_work_on = string ).
           remove_leading_trailing_spaces( CHANGING string_to_work_on = default ).

--- a/src/zcl_aff_writer.clas.abap
+++ b/src/zcl_aff_writer.clas.abap
@@ -574,7 +574,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
 
   METHOD get_infos_of_values_link.
     DATA(link) = values_link.
-    REPLACE ALL OCCURRENCES OF regex `[\s]` IN link WITH `` ##REGEX_POSIX.
+    REPLACE ALL OCCURRENCES OF REGEX `[\s]` IN link WITH `` ##REGEX_POSIX.
     REPLACE ALL OCCURRENCES OF `data:` IN link WITH ``.
     SPLIT link AT '.' INTO TABLE DATA(split_at_point).
     IF lines( split_at_point ) = 2.
@@ -629,8 +629,8 @@ CLASS zcl_aff_writer IMPLEMENTATION.
 
   METHOD get_default_from_link.
     DATA(link_to_work_on) = link.
-    REPLACE ALL OCCURRENCES OF regex `(@link|data:)` IN link_to_work_on WITH `` ##REGEX_POSIX.
-    REPLACE ALL OCCURRENCES OF regex `[\s]` IN link_to_work_on WITH `` ##REGEX_POSIX.
+    REPLACE ALL OCCURRENCES OF REGEX `(@link|data:)` IN link_to_work_on WITH `` ##REGEX_POSIX.
+    REPLACE ALL OCCURRENCES OF REGEX `[\s]` IN link_to_work_on WITH `` ##REGEX_POSIX.
     SPLIT link_to_work_on AT '.' INTO TABLE DATA(splitted).
     IF validate_default_link( splitted_link = splitted fullname_of_type = fullname_of_type element_type = element_type ) = abap_true.
       DATA(default_abap) = splitted[ lines( splitted ) ].
@@ -717,7 +717,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
             default = default && repeat( val = '0' occ = 6 - strlen( default ) ).
           ENDIF.
           IF element_description->type_kind = cl_abap_typedescr=>typekind_utclong.
-            REPLACE regex `T|t` IN default WITH ` ` ##REGEX_POSIX.
+            REPLACE REGEX `T|t` IN default WITH ` ` ##REGEX_POSIX.
           ENDIF.
           remove_leading_trailing_spaces( CHANGING string_to_work_on = string ).
           remove_leading_trailing_spaces( CHANGING string_to_work_on = default ).

--- a/src/zcl_aff_writer_json_schema.clas.abap
+++ b/src/zcl_aff_writer_json_schema.clas.abap
@@ -787,7 +787,7 @@ CLASS zcl_aff_writer_json_schema IMPLEMENTATION.
       LOOP AT ddic_fixed_values ASSIGNING FIELD-SYMBOL(<value>).
         DATA text TYPE string.
         text = <value>-ddtext.
-        REPLACE ALL OCCURRENCES OF PCRE '\s' IN text WITH '_'.
+        REPLACE ALL OCCURRENCES OF REGEX '\s' IN text WITH '_'  ##REGEX_POSIX.
         APPEND apply_formatting( text ) TO result.
       ENDLOOP.
     ENDIF.

--- a/src/zcl_aff_writer_xslt.clas.testclasses.abap
+++ b/src/zcl_aff_writer_xslt.clas.testclasses.abap
@@ -31,7 +31,7 @@ INTERFACE lif_test_types.
   TYPES:
     BEGIN OF include_in_include.
       INCLUDE TYPE include.
-TYPES END OF include_in_include.
+  TYPES END OF include_in_include.
 
   TYPES:
     BEGIN OF structure_include_in_include.

--- a/src/zcl_aff_writer_xslt.clas.testclasses.abap
+++ b/src/zcl_aff_writer_xslt.clas.testclasses.abap
@@ -31,7 +31,7 @@ INTERFACE lif_test_types.
   TYPES:
     BEGIN OF include_in_include.
       INCLUDE TYPE include.
-  TYPES END OF include_in_include.
+TYPES END OF include_in_include.
 
   TYPES:
     BEGIN OF structure_include_in_include.


### PR DESCRIPTION
For compatibility reasons (for the time being we replace PCRE regex by POSIX regex). This helps us to use the code also in release 7.54

Closed #5 

