### PR TITLE
lint config: two constants not needed anymore

### DIFF
--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -17,7 +17,7 @@
   "syntax": {
     "version": "v754",
     "errorNamespace": "^(Z|Y|LCL_|TY_|LIF_)",
-    "globalConstants": ["seoc_clstype_interface", "seoc_clstype_class", "srext_ext_xslt_source"]
+    "globalConstants": ["srext_ext_xslt_source"]
   },
   "rules": {
     "align_parameters": false,


### PR DESCRIPTION
not required anymore after https://github.com/SAP/abap-file-formats-tools/pull/52