### PR TITLE
XSLT writer overwrites enum values

### DIFF
--- a/src/zcl_aff_writer_xslt.clas.abap
+++ b/src/zcl_aff_writer_xslt.clas.abap
@@ -532,7 +532,7 @@ CLASS zcl_aff_writer_xslt IMPLEMENTATION.
       ASSIGN (name_of_source)=>(name_of_constant) TO <attr>.
       LOOP AT structure_of_values->components ASSIGNING FIELD-SYMBOL(<component>).
         DATA(fullname_of_component) = name_of_constant && '-' && <component>-name.
-        DATA(abap_doc_of_component) = call_reader_and_decode( name_of_source = name_of_source element_name   = fullname_of_component ).
+        DATA(abap_doc_of_component) = call_reader_and_decode( name_of_source = name_of_source element_name = fullname_of_component ).
         IF <component>-type_kind <> enum_type.
           RAISE EXCEPTION TYPE zcx_aff_tools MESSAGE e122(zaff_tools) WITH name_of_constant fullname_of_type.
         ENDIF.

--- a/src/zcl_aff_writer_xslt.clas.abap
+++ b/src/zcl_aff_writer_xslt.clas.abap
@@ -531,10 +531,16 @@ CLASS zcl_aff_writer_xslt IMPLEMENTATION.
       DATA(has_initial_component) = abap_false.
       ASSIGN (name_of_source)=>(name_of_constant) TO <attr>.
       LOOP AT structure_of_values->components ASSIGNING FIELD-SYMBOL(<component>).
+        DATA(fullname_of_component) = name_of_constant && '-' && <component>-name.
+        DATA(abap_doc_of_component) = call_reader_and_decode( name_of_source = name_of_source element_name   = fullname_of_component ).
         IF <component>-type_kind <> enum_type.
           RAISE EXCEPTION TYPE zcx_aff_tools MESSAGE e122(zaff_tools) WITH name_of_constant fullname_of_type.
         ENDIF.
-        DATA(json_name) = map_and_format_name( CONV #( <component>-name ) ).
+        IF abap_doc_of_component-enum_value IS INITIAL.
+          DATA(json_name) = map_and_format_name( CONV #( <component>-name ) ).
+        ELSE.
+          json_name = abap_doc_of_component-enum_value.
+        ENDIF.
         ASSIGN COMPONENT <component>-name OF STRUCTURE <attr> TO <fs_data>.
         INSERT VALUE #( abap = <fs_data>  json = json_name ) INTO TABLE value_mappings-value_mappings.
         IF <fs_data> IS INITIAL.

--- a/src/zcl_aff_writer_xslt.clas.testclasses.abap
+++ b/src/zcl_aff_writer_xslt.clas.testclasses.abap
@@ -3537,7 +3537,7 @@ CLASS ltcl_integration_test_ad IMPLEMENTATION.
 
   METHOD struc_with_own_enum_values.
     DATA test_type TYPE zcl_aff_test_types=>struc_with_own_enum_values.
-    test_type = VALUE #( enum_component =  'AA' ).
+    test_type = VALUE #( enum_component = 'AA' ).
     exp_json = VALUE #(
         ( `{` )
         ( `    "enumComponent": "AAAA"` )

--- a/src/zcl_aff_writer_xslt.clas.testclasses.abap
+++ b/src/zcl_aff_writer_xslt.clas.testclasses.abap
@@ -1690,7 +1690,8 @@ CLASS ltcl_type_writer_xslt_ad DEFINITION FINAL FOR TESTING
       type_of_enumtype_and_co_differ FOR TESTING RAISING cx_static_check,
       wrong_default_type_link FOR TESTING RAISING cx_static_check,
       structure_with_enums FOR TESTING RAISING cx_static_check,
-      structure_with_default_problem FOR TESTING RAISING cx_static_check.
+      structure_with_default_problem FOR TESTING RAISING cx_static_check,
+      struc_with_own_enum_values FOR TESTING RAISING cx_static_check.
 ENDCLASS.
 
 CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
@@ -2842,6 +2843,38 @@ CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
                                                              exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.
 
+  METHOD struc_with_own_enum_values.
+  DATA test_type TYPE zcl_aff_test_types=>struc_with_own_enum_values.
+    DATA(act_output) = test_generator->generate_type( test_type ).
+    me->exp_transformation = VALUE #(
+        ( `<tt:cond>` )
+        ( `  <object>` )
+        ( `    <tt:group>` )
+        ( `      <tt:cond frq="?">` )
+        ( `        <str name="enumComponent">` )
+        ( `          <tt:value ref="ENUM_COMPONENT" map="` )
+        ( `            val('AA')=xml('AAAA'),` )
+        ( `            val('BB')=xml('BBBB')` )
+        ( `          "/>` )
+        ( `        </str>` )
+        ( `      </tt:cond>` )
+        ( `      <tt:d-cond frq="*">` )
+        ( `         <_ tt:lax="on">` )
+        ( `          <tt:call-method class="CL_AFF_XSLT_CALLBACK_TYPE" name="RAISE_DIFFERENT_TYPE_EXCEPTION" reader="IO_READER">` )
+        ( `            <tt:with-parameter name="MEMBERS" val="'enumComponent;'"/>` )
+        ( `          </tt:call-method>` )
+        ( `          <tt:skip/>` )
+        ( `        </_>` )
+        ( `      </tt:d-cond>` )
+        ( `      <tt:d-cond frq="?">` )
+        ( `        <__/>` )
+        ( `      </tt:d-cond>` )
+        ( `    </tt:group>` )
+        ( `  </object>` )
+        ( `</tt:cond>` ) ).
+    validate_output( act_output ).
+  ENDMETHOD.
+
   METHOD validate_output.
     DATA exp TYPE string_table.
 
@@ -2922,6 +2955,8 @@ RISK LEVEL DANGEROUS.
       structure_with_include FOR TESTING RAISING cx_static_check,
 
       structure_with_default_problem FOR TESTING RAISING cx_static_check,
+
+      struc_with_own_enum_values FOR TESTING RAISING cx_static_check,
 
       from_abap_to_json
         IMPORTING
@@ -3491,6 +3526,21 @@ CLASS ltcl_integration_test_ad IMPLEMENTATION.
         ( `      "mySecondElement": 9 ` )
         ( `    },` )
         ( `    "otherElement": 0` )
+        ( `}` ) ).
+    do_integration_test(
+      EXPORTING
+        test_type = test_type
+      CHANGING
+        act_data  = test_type
+    ).
+  ENDMETHOD.
+
+  METHOD struc_with_own_enum_values.
+    DATA test_type TYPE zcl_aff_test_types=>struc_with_own_enum_values.
+    test_type = VALUE #( enum_component =  'AA' ).
+    exp_json = VALUE #(
+        ( `{` )
+        ( `    "enumComponent": "AAAA"` )
         ( `}` ) ).
     do_integration_test(
       EXPORTING


### PR DESCRIPTION
Now, also the xslt writer overwrites enum values if provided via ABAP Doc