### PR TITLE
escape preceding zeros

### DIFF
--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -32,7 +32,7 @@
     "unnecessary_pragma": true,
     "no_chained_assignment": true,
     "nrob_consistency": true,
-    "omit_preceding_zeros": false,
+    "omit_preceding_zeros": true,
     "prefer_corresponding": true,
     "slow_parameter_passing": true,
     "static_call_via_instance": true,

--- a/src/zcl_aff_log.clas.testclasses.abap
+++ b/src/zcl_aff_log.clas.testclasses.abap
@@ -201,11 +201,11 @@ CLASS ltcl_log_unit_test IMPLEMENTATION.
   METHOD get_sy_message.
     MESSAGE i000(zaff_tools) WITH '1' '2' '3' '4' INTO DATA(message) ##NEEDED.
     DATA(act_message) = zcl_aff_log=>get_sy_message( ).
-    cl_abap_unit_assert=>assert_equals( exp = VALUE symsg( msgid = 'ZAFF_TOOLS' msgno = 000 msgty = 'I' msgv1 = '1' msgv2 = '2' msgv3 = '3' msgv4 = '4' ) act = act_message ).
+    cl_abap_unit_assert=>assert_equals( exp = VALUE symsg( msgid = 'ZAFF_TOOLS' msgno = '000' msgty = 'I' msgv1 = '1' msgv2 = '2' msgv3 = '3' msgv4 = '4' ) act = act_message ).
 
     MESSAGE e001(zaff_tools) INTO message.
     act_message = zcl_aff_log=>get_sy_message( ).
-    cl_abap_unit_assert=>assert_equals( exp = VALUE symsg( msgid = 'ZAFF_TOOLS' msgno = 001 msgty = 'E' ) act = act_message ).
+    cl_abap_unit_assert=>assert_equals( exp = VALUE symsg( msgid = 'ZAFF_TOOLS' msgno = '001' msgty = 'E' ) act = act_message ).
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/zcl_aff_writer_xslt.clas.testclasses.abap
+++ b/src/zcl_aff_writer_xslt.clas.testclasses.abap
@@ -3137,7 +3137,7 @@ CLASS ltcl_integration_test_ad IMPLEMENTATION.
             inner_struc = VALUE #(
                 inner_element = 50 )
             field2 = 'ZZ'
-           field_with_values = 01 ).
+           field_with_values = '01' ).
     DATA act_data LIKE test_type.
 
     exp_json = VALUE #(

--- a/src/zcx_aff_tools.clas.abap
+++ b/src/zcx_aff_tools.clas.abap
@@ -29,7 +29,7 @@ CLASS zcx_aff_tools IMPLEMENTATION.
     IF message IS NOT INITIAL.
       cl_message_helper=>set_msg_vars_for_clike( message ).
       if_t100_message~t100key = VALUE #( msgid = 'ZAFF_TOOLS'
-                                         msgno = 000
+                                         msgno = '000'
                                          attr1 = 'IF_T100_DYN_MSG~MSGV1'
                                          attr2 = 'IF_T100_DYN_MSG~MSGV2'
                                          attr3 = 'IF_T100_DYN_MSG~MSGV3'
@@ -40,7 +40,7 @@ CLASS zcx_aff_tools IMPLEMENTATION.
       if_t100_dyn_msg~msgv3 = sy-msgv3.
       if_t100_dyn_msg~msgv4 = sy-msgv4.
     ELSEIF textid IS INITIAL.
-      if_t100_message~t100key = VALUE #( msgid = 'ZAFF_TOOLS' msgno = 001 ).
+      if_t100_message~t100key = VALUE #( msgid = 'ZAFF_TOOLS' msgno = '001' ).
     ELSE.
       if_t100_message~t100key = textid.
     ENDIF.

--- a/src/zcx_aff_tools.clas.testclasses.abap
+++ b/src/zcx_aff_tools.clas.testclasses.abap
@@ -15,7 +15,7 @@ CLASS ltcl_aff_root IMPLEMENTATION.
     DATA(exception) = NEW zcx_aff_tools( ).
 
     cl_abap_unit_assert=>assert_equals( exp = 'ZAFF_TOOLS' act = exception->if_t100_message~t100key-msgid ).
-    cl_abap_unit_assert=>assert_equals( exp = 001 act = exception->if_t100_message~t100key-msgno ).
+    cl_abap_unit_assert=>assert_equals( exp = '001' act = exception->if_t100_message~t100key-msgno ).
   ENDMETHOD.
 
   METHOD exception_with_message.
@@ -38,7 +38,7 @@ CLASS ltcl_aff_root IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( exp = sy-msgv3 act = exception->if_t100_dyn_msg~msgv3 ).
     cl_abap_unit_assert=>assert_equals( exp = sy-msgv4 act = exception->if_t100_dyn_msg~msgv4 ).
     cl_abap_unit_assert=>assert_equals( exp = 'ZAFF_TOOLS' act = exception->if_t100_message~t100key-msgid ).
-    cl_abap_unit_assert=>assert_equals( exp = 000 act = exception->if_t100_message~t100key-msgno ).
+    cl_abap_unit_assert=>assert_equals( exp = '000' act = exception->if_t100_message~t100key-msgno ).
     cl_abap_unit_assert=>assert_equals( exp = 'IF_T100_DYN_MSG~MSGV1' act = exception->if_t100_message~t100key-attr1 ).
     cl_abap_unit_assert=>assert_equals( exp = 'IF_T100_DYN_MSG~MSGV2' act = exception->if_t100_message~t100key-attr2 ).
     cl_abap_unit_assert=>assert_equals( exp = 'IF_T100_DYN_MSG~MSGV3' act = exception->if_t100_message~t100key-attr3 ).


### PR DESCRIPTION
ABAP should convert these as needed

causes a problem in javascript as numbers with preceding zeros are not allowed