### PR TITLE
Add action that uploads a standalone PROG as zip

### DIFF
--- a/.github/workflows/upload-standalone.yml
+++ b/.github/workflows/upload-standalone.yml
@@ -1,0 +1,25 @@
+name: standalone-program
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-merged:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+    - name: Run npm steps
+      run: |
+        npm install
+        npm run merge
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: z_generate_repo.prog.abap
+        path: z_generate_repo.prog.abap

--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -1,5 +1,4 @@
 {
-
   "global": {
     "files": "/src/**/*.*",
     "exclude": ["src/z_generate_repo.prog.abap"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@abaplint/cli": "^2.89.14",
         "@abaplint/database-sqlite": "^2.0.11",
         "@abaplint/runtime": "^2.0.19",
-        "@abaplint/transpiler-cli": "^2.0.19"
+        "@abaplint/transpiler-cli": "^2.0.19",
+        "abapmerge": "^0.14.3"
       }
     },
     "node_modules/@abaplint/cli": {
@@ -47,6 +48,25 @@
         "abap_transpile": "abap_transpile"
       }
     },
+    "node_modules/abapmerge": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/abapmerge/-/abapmerge-0.14.3.tgz",
+      "integrity": "sha512-f0CV09NRgirtgeQxH1gkBqu24dJjBYHq7zTdj9Tf1GA1dUG/FEM1ZOUd1mw8bflq2YxCIWWBJXXeGtQ2450UiQ==",
+      "dependencies": {
+        "commander": "^7.1.0"
+      },
+      "bin": {
+        "abapmerge": "abapmerge"
+      }
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/sql.js": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.6.2.tgz",
@@ -76,6 +96,19 @@
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.0.19.tgz",
       "integrity": "sha512-bDIKRA6PMlyA4W9vYNZE3s00sjLGx4yS1GPxImVl6f7QOARctZvPQ9xZKMuH3FufyIaDz0Z8DckuxHC3NPvCkQ=="
+    },
+    "abapmerge": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/abapmerge/-/abapmerge-0.14.3.tgz",
+      "integrity": "sha512-f0CV09NRgirtgeQxH1gkBqu24dJjBYHq7zTdj9Tf1GA1dUG/FEM1ZOUd1mw8bflq2YxCIWWBJXXeGtQ2450UiQ==",
+      "requires": {
+        "commander": "^7.1.0"
+      }
+    },
+    "commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
     },
     "sql.js": {
       "version": "1.6.2",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,16 @@
     "lint": "abaplint",
     "unit": "rm -rf output && abap_transpile && echo RUNNING && node output/index.mjs",
     "test": "npm run lint && npm run downport && npm run unit",
-    "downport": "rm -rf downport && cp -r src downport && cp deps/* downport && rm downport/*.prog.abap && rm downport/zcl_aff_writer_xslt.clas.testclasses.abap && abaplint --fix abaplint-downport.jsonc"
+    "downport": "rm -rf downport && cp -r src downport && cp deps/* downport && rm downport/*.prog.abap && rm downport/zcl_aff_writer_xslt.clas.testclasses.abap && abaplint --fix abaplint-downport.jsonc",
+    "merge": "rm src/z_generate_json_schema.prog.abap && abapmerge -f src/z_generate_repo.prog.abap -c z_generate_repo > z_generate_repo.prog.abap"
+
   },
   "license": "MIT",
   "dependencies": {
     "@abaplint/cli": "^2.89.14",
     "@abaplint/runtime": "^2.0.19",
     "@abaplint/database-sqlite": "^2.0.11",
-    "@abaplint/transpiler-cli": "^2.0.19"
+    "@abaplint/transpiler-cli": "^2.0.19",
+    "abapmerge": "^0.14.3"
   }
 }


### PR DESCRIPTION
  - abapmerge has problems if there is more than one report in repo ->
npm script deletes the second report (hack!)
  - issues on abapmerge https://github.com/larshp/abapmerge/issues/300
  - uploaded zip archive is found under the tab `Actions` and select
Workflow `standalone-program`

-----
Make changes from https://github.com/SAP/abap-file-formats-tools/issues/92 easy (copy&paste) consumable without having to pull the repository to the ABAP system via abapGit.