### PR TITLE
Rename the standalone report

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "unit": "rm -rf output && abap_transpile && echo RUNNING && node output/index.mjs",
     "test": "npm run lint && npm run downport && npm run unit",
     "downport": "rm -rf downport && cp -r src downport && cp deps/* downport && rm downport/*.prog.abap && rm downport/zcl_aff_writer_xslt.clas.testclasses.abap && abaplint --fix abaplint-downport.jsonc",
-    "merge": "rm src/z_generate_json_schema.prog.abap && abapmerge -f src/z_generate_repo.prog.abap -c z_generate_repo > z_generate_repo.prog.abap"
+    "merge": "rm src/z_generate_json_schema.prog.abap && abapmerge -f src/z_generate_repo.prog.abap -c saff_generate_repo > saff_generate_repo.prog.abap"
 
   },
   "license": "MIT",


### PR DESCRIPTION
This just renames the report within the action. The renaming can still done by hand, while copy&pasting the ABAP source in the system.