### PR TITLE
Remove usage of msg class

### DIFF
--- a/src/z_generate_repo.prog.abap
+++ b/src/z_generate_repo.prog.abap
@@ -763,7 +763,8 @@ CLASS lcl_generator IMPLEMENTATION.
     " getting the XSLT/Schema of the type
     TRY.
         content = generator->generate_type( <field> ).
-      CATCH zcx_aff_tools .
+      CATCH zcx_aff_tools into data(exception).
+        generator_log->add_message_dev( message = exception->get_text( ) type = 'W' ).
         CLEAR content.
         INSERT |The generator couldn't generate the schema/XSLT for type { absolute_typename }| INTO TABLE report_log ##NO_TEXT.
         RETURN.

--- a/src/z_generate_repo.prog.abap
+++ b/src/z_generate_repo.prog.abap
@@ -1729,7 +1729,8 @@ CLASS ltc_generator IMPLEMENTATION.
     expected_report_log = VALUE #(
   ( `The generator couldn't generate the schema/XSLT for type \INTERFACE=IF_AFF_INTF_V1\TYPE=TY_MAIN` )
   ).
-    CLEAR expected_log_messages.
+
+    expected_log_messages = value #( ( text = `I:ZAFF_TOOLS:001` type = 'W' )  ).
     assert_logs_and_file_handler( ).
   ENDMETHOD.
 

--- a/src/zcl_aff_generator.clas.abap
+++ b/src/zcl_aff_generator.clas.abap
@@ -117,7 +117,8 @@ CLASS zcl_aff_generator IMPLEMENTATION.
           table_name        = type_name
           table_description = CAST #( type_description ) ).
       WHEN OTHERS.
-        RAISE EXCEPTION NEW zcx_aff_tools( ).
+        data(msg) = log->get_message( msgno = 100 msgv1 = conv #( type_description->kind ) ).
+        RAISE EXCEPTION NEW zcx_aff_tools( message = msg ).
     ENDCASE.
   ENDMETHOD.
 

--- a/src/zcl_aff_generator.clas.abap
+++ b/src/zcl_aff_generator.clas.abap
@@ -117,7 +117,7 @@ CLASS zcl_aff_generator IMPLEMENTATION.
           table_name        = type_name
           table_description = CAST #( type_description ) ).
       WHEN OTHERS.
-        RAISE EXCEPTION TYPE zcx_aff_tools MESSAGE e100(zaff_tools) WITH type_description->kind.
+        RAISE EXCEPTION NEW zcx_aff_tools( ).
     ENDCASE.
   ENDMETHOD.
 

--- a/src/zcl_aff_generator.clas.abap
+++ b/src/zcl_aff_generator.clas.abap
@@ -98,7 +98,7 @@ CLASS zcl_aff_generator IMPLEMENTATION.
   METHOD check_mandatory_fields.
     DATA(components) = structure_description->get_components( ).
     IF NOT ( line_exists( components[ name = 'HEADER' ] ) AND line_exists( components[ name = 'FORMAT_VERSION' ] ) ).
-      log->add_message_dev( type ='W' message = zif_aff_log=>co_msg124 component_name = structure_description->get_relative_name( ) ).
+      log->add_message_dev( type = 'W' message = zif_aff_log=>co_msg124 component_name = structure_description->get_relative_name( ) ).
     ENDIF.
   ENDMETHOD.
 
@@ -117,7 +117,7 @@ CLASS zcl_aff_generator IMPLEMENTATION.
           table_name        = type_name
           table_description = CAST #( type_description ) ).
       WHEN OTHERS.
-        data(msg) = log->get_message( msgno = 100 msgv1 = conv #( type_description->kind ) ).
+        DATA(msg) = log->get_message( msgno = 100 msgv1 = CONV #( type_description->kind ) ).
         RAISE EXCEPTION NEW zcx_aff_tools( message = msg ).
     ENDCASE.
   ENDMETHOD.

--- a/src/zcl_aff_generator.clas.testclasses.abap
+++ b/src/zcl_aff_generator.clas.testclasses.abap
@@ -383,8 +383,6 @@ CLASS ltcl_type_generator IMPLEMENTATION.
     ENDTRY.
 
     cl_abap_unit_assert=>assert_initial( act_result ).
-    cl_abap_unit_assert=>assert_equals( exp = 'ZAFF_TOOLS' act = exception->if_t100_message~t100key-msgid ).
-    cl_abap_unit_assert=>assert_equals( exp = 100 act = exception->if_t100_message~t100key-msgno ).
   ENDMETHOD.
 
   METHOD complex_structure_aff_class.

--- a/src/zcl_aff_generator.clas.testclasses.abap
+++ b/src/zcl_aff_generator.clas.testclasses.abap
@@ -379,7 +379,7 @@ CLASS ltcl_type_generator IMPLEMENTATION.
     TRY.
         DATA(act_result) = cut->generate_type( class_reference ).
         cl_abap_unit_assert=>fail( msg = 'Exception expected' ).
-      CATCH zcx_aff_tools INTO DATA(exception) ##NO_HANDLER.
+      CATCH zcx_aff_tools ##NO_HANDLER.
     ENDTRY.
 
     cl_abap_unit_assert=>assert_initial( act_result ).

--- a/src/zcl_aff_log.clas.abap
+++ b/src/zcl_aff_log.clas.abap
@@ -12,12 +12,27 @@ CLASS zcl_aff_log DEFINITION
       "! @parameter result | The actual system message
       get_sy_message
         RETURNING VALUE(result) TYPE symsg.
+
+    METHODS:
+      constructor.
   PROTECTED SECTION.
 
   PRIVATE SECTION.
+    TYPES: BEGIN OF ty_msg,
+             msgno TYPE i,
+             str1  TYPE c LENGTH 100,
+             str2  TYPE c LENGTH 100,
+             str3  TYPE c LENGTH 100,
+             str4  TYPE c LENGTH 100,
+           END OF ty_msg.
+
+    TYPES: tt_msg TYPE STANDARD TABLE OF ty_msg WITH DEFAULT KEY.
+
     DATA:
       messages     TYPE zif_aff_log=>tt_log_out,
+      message_table type tt_msg,
       max_severity TYPE symsgty.
+
 
     METHODS:
       add_message
@@ -127,6 +142,15 @@ CLASS zcl_aff_log IMPLEMENTATION.
       msgv4 = sy-msgv4 ).
   ENDMETHOD.
 
+  METHOD zif_aff_log~get_message.
+    IF line_exists( message_table[ msgno = msgno ] ).
+      DATA(message_entry) = VALUE #( message_table[ msgno = msgno ] ).
+      message = message_entry-str1 && ` ` && msgv1 && ` ` &&
+                message_entry-str2 && ` ` && msgv2 && ` ` &&
+                message_entry-str3 && ` ` && msgv3 && ` ` &&
+                message_entry-str4 && ` ` && msgv4.
+    endif.
+  ENDMETHOD.
 
   METHOD set_max_severity.
     IF type = zif_aff_log=>c_message_type-error.
@@ -143,5 +167,12 @@ CLASS zcl_aff_log IMPLEMENTATION.
   ENDMETHOD.
 
 
+
+  METHOD constructor.
+    " do fill tt_msg
+    append value #( msgno = 100 str1 = `The type`  str2 = `is not supported by the generator`) to message_table.
+    append value #( msgno = 101 str1 = `The node`  str2 = `is not supported by the generator`) to message_table.
+
+  ENDMETHOD.
 
 ENDCLASS.

--- a/src/zcl_aff_log.clas.abap
+++ b/src/zcl_aff_log.clas.abap
@@ -29,9 +29,9 @@ CLASS zcl_aff_log DEFINITION
     TYPES: tt_msg TYPE STANDARD TABLE OF ty_msg WITH DEFAULT KEY.
 
     DATA:
-      messages     TYPE zif_aff_log=>tt_log_out,
-      message_table type tt_msg,
-      max_severity TYPE symsgty.
+      messages      TYPE zif_aff_log=>tt_log_out,
+      message_table TYPE tt_msg,
+      max_severity  TYPE symsgty.
 
 
     METHODS:
@@ -149,7 +149,7 @@ CLASS zcl_aff_log IMPLEMENTATION.
                 message_entry-str2 && ` ` && msgv2 && ` ` &&
                 message_entry-str3 && ` ` && msgv3 && ` ` &&
                 message_entry-str4 && ` ` && msgv4.
-    endif.
+    ENDIF.
   ENDMETHOD.
 
   METHOD set_max_severity.
@@ -170,8 +170,8 @@ CLASS zcl_aff_log IMPLEMENTATION.
 
   METHOD constructor.
     " do fill tt_msg
-    append value #( msgno = 100 str1 = `The type`  str2 = `is not supported by the generator`) to message_table.
-    append value #( msgno = 101 str1 = `The node`  str2 = `is not supported by the generator`) to message_table.
+    APPEND VALUE #( msgno = 100 str1 = `The type`  str2 = `is not supported by the generator`) TO message_table.
+    APPEND VALUE #( msgno = 101 str1 = `The node`  str2 = `is not supported by the generator`) TO message_table.
 
   ENDMETHOD.
 

--- a/src/zcl_aff_writer.clas.abap
+++ b/src/zcl_aff_writer.clas.abap
@@ -372,7 +372,8 @@ CLASS zcl_aff_writer IMPLEMENTATION.
         add_to_stack( VALUE #( operation = zif_aff_writer=>operation-close_table name = node_name ) ).
 
       WHEN OTHERS.
-        RAISE EXCEPTION TYPE zcx_aff_tools MESSAGE e101(zaff_tools) WITH node_description->kind.
+        data(msg) = log->get_message( msgno = 101 msgv1 = conv #( node_description->kind ) ).
+        RAISE EXCEPTION NEW zcx_aff_tools( message = msg ).
     ENDCASE.
   ENDMETHOD.
 

--- a/src/zcl_aff_writer.clas.abap
+++ b/src/zcl_aff_writer.clas.abap
@@ -372,7 +372,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
         add_to_stack( VALUE #( operation = zif_aff_writer=>operation-close_table name = node_name ) ).
 
       WHEN OTHERS.
-        data(msg) = log->get_message( msgno = 101 msgv1 = conv #( node_description->kind ) ).
+        DATA(msg) = log->get_message( msgno = 101 msgv1 = CONV #( node_description->kind ) ).
         RAISE EXCEPTION NEW zcx_aff_tools( message = msg ).
     ENDCASE.
   ENDMETHOD.

--- a/src/zif_aff_log.intf.abap
+++ b/src/zif_aff_log.intf.abap
@@ -64,7 +64,7 @@ INTERFACE zif_aff_log
       IMPORTING
         type           TYPE symsgty
         message        TYPE string
-        component_name TYPE string optional,
+        component_name TYPE string OPTIONAL,
 
 
     "! Returns message for a given msg number
@@ -72,12 +72,12 @@ INTERFACE zif_aff_log
     "!
     "! @parameter msgno | the message number
     get_message
-      importing
-        msgno type syst_msgno
-        msgv1 type syst_msgv optional
-        msgv2 type syst_msgv optional
-        msgv3 type syst_msgv optional
-        msgv4 type syst_msgv optional
+      IMPORTING
+                msgno          TYPE syst_msgno
+                msgv1          TYPE syst_msgv OPTIONAL
+                msgv2          TYPE syst_msgv OPTIONAL
+                msgv3          TYPE syst_msgv OPTIONAL
+                msgv4          TYPE syst_msgv OPTIONAL
       RETURNING VALUE(message) TYPE string,
 
 

--- a/src/zif_aff_log.intf.abap
+++ b/src/zif_aff_log.intf.abap
@@ -64,7 +64,22 @@ INTERFACE zif_aff_log
       IMPORTING
         type           TYPE symsgty
         message        TYPE string
-        component_name TYPE string,
+        component_name TYPE string optional,
+
+
+    "! Returns message for a given msg number
+    "! This emulates the behaviour of the object type message classes
+    "!
+    "! @parameter msgno | the message number
+    get_message
+      importing
+        msgno type syst_msgno
+        msgv1 type syst_msgv optional
+        msgv2 type syst_msgv optional
+        msgv3 type syst_msgv optional
+        msgv4 type syst_msgv optional
+      RETURNING VALUE(message) TYPE string,
+
 
 
     "! Adds an exception to the log. Actually not the exception is added


### PR DESCRIPTION
There are some obsolete usages of msag class, e.g. the exception with msag is CATCHed with a customized msg. This pull request aims to delete them.