### PR TITLE
Remove use of ENUMs in logic

### DIFF
--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -175,7 +175,7 @@
       "exclude": ["zcl_aff_test_types"]
     },
     "unused_variables": {
-      "exclude": ["zcl_aff_test_types"]
+      "exclude": ["zcl_aff_test_types", "zcl_aff_writer.clas.testclasses"]
     },
     "use_bool_expression": true,
     "use_class_based_exceptions": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@abaplint/cli": "^2.91.18",
+        "@abaplint/cli": "^2.91.21",
         "@abaplint/database-sqlite": "^2.1.6",
-        "@abaplint/runtime": "^2.1.17",
-        "@abaplint/transpiler-cli": "^2.1.17",
+        "@abaplint/runtime": "^2.1.19",
+        "@abaplint/transpiler-cli": "^2.1.19",
         "abapmerge": "^0.14.7"
       }
     },
     "node_modules/@abaplint/cli": {
-      "version": "2.91.18",
-      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.91.18.tgz",
-      "integrity": "sha512-QuPEeecpW3hTRhgxpUNqHhtA+h0aFd0cEy8qY0KlZ4c70qIyNOJsdSlsHmBjx6Iqrw9lJyjmrz+y4xOD35WLiw==",
+      "version": "2.91.21",
+      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.91.21.tgz",
+      "integrity": "sha512-Vg5pVs4AdnQcdXJoEqJanJtxv+LOwimutXrqJ/VEzgbcZRE17d96CJ9t3w/S4ZSysymTmkGRTImhX5Z5UoDtSg==",
       "bin": {
         "abaplint": "abaplint"
       },
@@ -36,14 +36,14 @@
       }
     },
     "node_modules/@abaplint/runtime": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.1.17.tgz",
-      "integrity": "sha512-nLLUCOVms0PGvyRQqoIgzQy8a+vCks3LQ80nRxieiwCaTzwGw6xQ2ukTWK7u+lq+7a1g7U7bm/dbXuqAr46Ogw=="
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.1.19.tgz",
+      "integrity": "sha512-R4Pae5jao67QOD9SgOKAgrVC4uZ/zh6avqjE1iCecN2XFewXL6itFtgmRdI3jUe7eTOjNBl8waPHwGJVqwob4w=="
     },
     "node_modules/@abaplint/transpiler-cli": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.1.17.tgz",
-      "integrity": "sha512-IaX8V+SjGOOEAvvwapRbOXYcpDbrLKy+YhGDUr1m0v35Y2eyboFGm9gjxBwoBLQFaCwV/G4WMf1kw6b7i4teVw==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.1.19.tgz",
+      "integrity": "sha512-tgUUTORB6Ch8Cf3N9Y8iF/UGa0wu/ras/IeW7w+QP+3f3Hc578iPTgF4RjAIZuKkeUWM8OZNDmKWIkWzWq/Kqw==",
       "bin": {
         "abap_transpile": "abap_transpile"
       }
@@ -75,9 +75,9 @@
   },
   "dependencies": {
     "@abaplint/cli": {
-      "version": "2.91.18",
-      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.91.18.tgz",
-      "integrity": "sha512-QuPEeecpW3hTRhgxpUNqHhtA+h0aFd0cEy8qY0KlZ4c70qIyNOJsdSlsHmBjx6Iqrw9lJyjmrz+y4xOD35WLiw=="
+      "version": "2.91.21",
+      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.91.21.tgz",
+      "integrity": "sha512-Vg5pVs4AdnQcdXJoEqJanJtxv+LOwimutXrqJ/VEzgbcZRE17d96CJ9t3w/S4ZSysymTmkGRTImhX5Z5UoDtSg=="
     },
     "@abaplint/database-sqlite": {
       "version": "2.1.6",
@@ -88,14 +88,14 @@
       }
     },
     "@abaplint/runtime": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.1.17.tgz",
-      "integrity": "sha512-nLLUCOVms0PGvyRQqoIgzQy8a+vCks3LQ80nRxieiwCaTzwGw6xQ2ukTWK7u+lq+7a1g7U7bm/dbXuqAr46Ogw=="
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.1.19.tgz",
+      "integrity": "sha512-R4Pae5jao67QOD9SgOKAgrVC4uZ/zh6avqjE1iCecN2XFewXL6itFtgmRdI3jUe7eTOjNBl8waPHwGJVqwob4w=="
     },
     "@abaplint/transpiler-cli": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.1.17.tgz",
-      "integrity": "sha512-IaX8V+SjGOOEAvvwapRbOXYcpDbrLKy+YhGDUr1m0v35Y2eyboFGm9gjxBwoBLQFaCwV/G4WMf1kw6b7i4teVw=="
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.1.19.tgz",
+      "integrity": "sha512-tgUUTORB6Ch8Cf3N9Y8iF/UGa0wu/ras/IeW7w+QP+3f3Hc578iPTgF4RjAIZuKkeUWM8OZNDmKWIkWzWq/Kqw=="
     },
     "abapmerge": {
       "version": "0.14.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@abaplint/cli": "^2.91.21",
-        "@abaplint/database-sqlite": "^2.1.6",
-        "@abaplint/runtime": "^2.1.19",
-        "@abaplint/transpiler-cli": "^2.1.19",
+        "@abaplint/cli": "^2.91.28",
+        "@abaplint/database-sqlite": "^2.1.20",
+        "@abaplint/runtime": "^2.1.23",
+        "@abaplint/transpiler-cli": "^2.1.23",
         "abapmerge": "^0.14.7"
       }
     },
     "node_modules/@abaplint/cli": {
-      "version": "2.91.21",
-      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.91.21.tgz",
-      "integrity": "sha512-Vg5pVs4AdnQcdXJoEqJanJtxv+LOwimutXrqJ/VEzgbcZRE17d96CJ9t3w/S4ZSysymTmkGRTImhX5Z5UoDtSg==",
+      "version": "2.91.28",
+      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.91.28.tgz",
+      "integrity": "sha512-c2IdfQbZeynJ4IUAv/891wOwQz5cg/oqVp/pc7yfQ9rTICBKFwHZLLb5JeMXo77w54pfvVrGRZdfPQIifwwEfg==",
       "bin": {
         "abaplint": "abaplint"
       },
@@ -28,22 +28,22 @@
       }
     },
     "node_modules/@abaplint/database-sqlite": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@abaplint/database-sqlite/-/database-sqlite-2.1.6.tgz",
-      "integrity": "sha512-Cixcpdh9MLD1Mk40rOM+h6AhOgmoNZFql7MEyvPUEq2BBYI6DzsJ2Bm3z2o/FWax39s08qgaGm+bMk2XZHJILQ==",
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/@abaplint/database-sqlite/-/database-sqlite-2.1.20.tgz",
+      "integrity": "sha512-XOwpiCp8FIZL1hzliCRMtdG9sX08O8GHwgGGQpfqEtvvh7hOU54c2T9hQiTBL9nx3d7zNU92C19cpKiU0qdtrg==",
       "dependencies": {
         "sql.js": "^1.7.0"
       }
     },
     "node_modules/@abaplint/runtime": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.1.19.tgz",
-      "integrity": "sha512-R4Pae5jao67QOD9SgOKAgrVC4uZ/zh6avqjE1iCecN2XFewXL6itFtgmRdI3jUe7eTOjNBl8waPHwGJVqwob4w=="
+      "version": "2.1.23",
+      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.1.23.tgz",
+      "integrity": "sha512-RFEZm336a8ABC5zC4EStlzKUQDp3Tgc/+61wm+x4OKvZOI29wFQaNt0p9hnY+i1Z4vOaz11LXX3meS7+KXY5ew=="
     },
     "node_modules/@abaplint/transpiler-cli": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.1.19.tgz",
-      "integrity": "sha512-tgUUTORB6Ch8Cf3N9Y8iF/UGa0wu/ras/IeW7w+QP+3f3Hc578iPTgF4RjAIZuKkeUWM8OZNDmKWIkWzWq/Kqw==",
+      "version": "2.1.23",
+      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.1.23.tgz",
+      "integrity": "sha512-1vevPbxtZkVissfeeNZdQqrptake8xrKecNt1fIEHN6JuW1sVcD6w0lgnJ1RIDOd2UJhrxxKqMJ0nRIANQgIXQ==",
       "bin": {
         "abap_transpile": "abap_transpile"
       }
@@ -75,27 +75,27 @@
   },
   "dependencies": {
     "@abaplint/cli": {
-      "version": "2.91.21",
-      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.91.21.tgz",
-      "integrity": "sha512-Vg5pVs4AdnQcdXJoEqJanJtxv+LOwimutXrqJ/VEzgbcZRE17d96CJ9t3w/S4ZSysymTmkGRTImhX5Z5UoDtSg=="
+      "version": "2.91.28",
+      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.91.28.tgz",
+      "integrity": "sha512-c2IdfQbZeynJ4IUAv/891wOwQz5cg/oqVp/pc7yfQ9rTICBKFwHZLLb5JeMXo77w54pfvVrGRZdfPQIifwwEfg=="
     },
     "@abaplint/database-sqlite": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@abaplint/database-sqlite/-/database-sqlite-2.1.6.tgz",
-      "integrity": "sha512-Cixcpdh9MLD1Mk40rOM+h6AhOgmoNZFql7MEyvPUEq2BBYI6DzsJ2Bm3z2o/FWax39s08qgaGm+bMk2XZHJILQ==",
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/@abaplint/database-sqlite/-/database-sqlite-2.1.20.tgz",
+      "integrity": "sha512-XOwpiCp8FIZL1hzliCRMtdG9sX08O8GHwgGGQpfqEtvvh7hOU54c2T9hQiTBL9nx3d7zNU92C19cpKiU0qdtrg==",
       "requires": {
         "sql.js": "^1.7.0"
       }
     },
     "@abaplint/runtime": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.1.19.tgz",
-      "integrity": "sha512-R4Pae5jao67QOD9SgOKAgrVC4uZ/zh6avqjE1iCecN2XFewXL6itFtgmRdI3jUe7eTOjNBl8waPHwGJVqwob4w=="
+      "version": "2.1.23",
+      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.1.23.tgz",
+      "integrity": "sha512-RFEZm336a8ABC5zC4EStlzKUQDp3Tgc/+61wm+x4OKvZOI29wFQaNt0p9hnY+i1Z4vOaz11LXX3meS7+KXY5ew=="
     },
     "@abaplint/transpiler-cli": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.1.19.tgz",
-      "integrity": "sha512-tgUUTORB6Ch8Cf3N9Y8iF/UGa0wu/ras/IeW7w+QP+3f3Hc578iPTgF4RjAIZuKkeUWM8OZNDmKWIkWzWq/Kqw=="
+      "version": "2.1.23",
+      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.1.23.tgz",
+      "integrity": "sha512-1vevPbxtZkVissfeeNZdQqrptake8xrKecNt1fIEHN6JuW1sVcD6w0lgnJ1RIDOd2UJhrxxKqMJ0nRIANQgIXQ=="
     },
     "abapmerge": {
       "version": "0.14.7",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@abaplint/cli": "^2.91.21",
-    "@abaplint/runtime": "^2.1.19",
-    "@abaplint/database-sqlite": "^2.1.6",
-    "@abaplint/transpiler-cli": "^2.1.19",
+    "@abaplint/cli": "^2.91.28",
+    "@abaplint/runtime": "^2.1.23",
+    "@abaplint/database-sqlite": "^2.1.20",
+    "@abaplint/transpiler-cli": "^2.1.23",
     "abapmerge": "^0.14.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@abaplint/cli": "^2.91.18",
-    "@abaplint/runtime": "^2.1.17",
+    "@abaplint/cli": "^2.91.21",
+    "@abaplint/runtime": "^2.1.19",
     "@abaplint/database-sqlite": "^2.1.6",
-    "@abaplint/transpiler-cli": "^2.1.17",
+    "@abaplint/transpiler-cli": "^2.1.19",
     "abapmerge": "^0.14.7"
   }
 }

--- a/src/zcl_aff_writer.clas.abap
+++ b/src/zcl_aff_writer.clas.abap
@@ -401,7 +401,11 @@ CLASS zcl_aff_writer IMPLEMENTATION.
 
 
   METHOD last_operation.
-    result = VALUE #( stack[ 1 ]-operation OPTIONAL ).
+    if stack is not initial.
+      result = VALUE #( stack[ 1 ]-operation OPTIONAL ).
+    else.
+      result = zif_aff_writer=>operation-initial.
+    endif.
   ENDMETHOD.
 
 

--- a/src/zcl_aff_writer.clas.abap
+++ b/src/zcl_aff_writer.clas.abap
@@ -12,7 +12,7 @@ CLASS zcl_aff_writer DEFINITION
   PROTECTED SECTION.
     TYPES:
       BEGIN OF ty_stack_entry,
-        operation TYPE zif_aff_writer=>enum_operation,
+        operation TYPE string,
         name      TYPE string,
       END OF ty_stack_entry.
 
@@ -25,7 +25,7 @@ CLASS zcl_aff_writer DEFINITION
 
     DATA:
       output                     TYPE string_table,
-      formatting_option          TYPE zif_aff_writer=>enum_formatting_option,
+      formatting_option          TYPE string,
       name_mappings              TYPE zif_aff_writer=>ty_name_mappings,
       abap_value_mappings        TYPE zif_aff_writer=>ty_abap_value_mappings,
       content                    TYPE string_table,
@@ -47,7 +47,7 @@ CLASS zcl_aff_writer DEFINITION
         RETURNING VALUE(result) TYPE string,
       get_json_type_from_description
         IMPORTING element_description TYPE REF TO cl_abap_elemdescr
-        RETURNING VALUE(result)       TYPE zif_aff_writer=>enum_type_info
+        RETURNING VALUE(result)       TYPE string
         RAISING   zcx_aff_tools,
 
       write_open_tag FINAL
@@ -60,7 +60,7 @@ CLASS zcl_aff_writer DEFINITION
         IMPORTING
           entry TYPE ty_stack_entry,
       last_operation FINAL
-        RETURNING VALUE(result) TYPE zif_aff_writer=>enum_operation,
+        RETURNING VALUE(result) TYPE string,
       append_to_previous_line FINAL
         IMPORTING
           string TYPE string,

--- a/src/zcl_aff_writer.clas.abap
+++ b/src/zcl_aff_writer.clas.abap
@@ -403,9 +403,9 @@ CLASS zcl_aff_writer IMPLEMENTATION.
   METHOD last_operation.
     IF stack IS NOT INITIAL.
       result = VALUE #( stack[ 1 ]-operation OPTIONAL ).
-    else.
+    ELSE.
       result = zif_aff_writer=>operation-initial.
-    endif.
+    ENDIF.
   ENDMETHOD.
 
 

--- a/src/zcl_aff_writer.clas.abap
+++ b/src/zcl_aff_writer.clas.abap
@@ -401,7 +401,7 @@ CLASS zcl_aff_writer IMPLEMENTATION.
 
 
   METHOD last_operation.
-    if stack is not initial.
+    IF stack IS NOT INITIAL.
       result = VALUE #( stack[ 1 ]-operation OPTIONAL ).
     else.
       result = zif_aff_writer=>operation-initial.

--- a/src/zcl_aff_writer.clas.testclasses.abap
+++ b/src/zcl_aff_writer.clas.testclasses.abap
@@ -187,13 +187,13 @@ CLASS ltcl_type_writer IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD get_type_info_string_like_enum.
-    types:
-      begin of enum my_enum,
+    TYPES:
+      BEGIN OF ENUM my_enum,
         option1,
         option2,
-      end of enum my_enum.
+      END OF ENUM my_enum.
 
-    cl_abap_unit_assert=>assert_equals( exp = zif_aff_writer=>type_info-string act = cut->get_json_type_from_description( get_element_description( value my_enum( ) ) ) ).
+    cl_abap_unit_assert=>assert_equals( exp = zif_aff_writer=>type_info-string act = cut->get_json_type_from_description( get_element_description( VALUE my_enum( ) ) ) ).
   ENDMETHOD.
 
   METHOD get_type_info_string_like.

--- a/src/zcl_aff_writer.clas.testclasses.abap
+++ b/src/zcl_aff_writer.clas.testclasses.abap
@@ -187,7 +187,7 @@ CLASS ltcl_type_writer IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD get_type_info_string_like_enum.
-    cl_abap_unit_assert=>assert_equals( exp = zif_aff_writer=>type_info-string act = cut->get_json_type_from_description( get_element_description( VALUE zif_aff_writer=>enum_type_info( ) ) ) ).
+    cl_abap_unit_assert=>assert_equals( exp = zif_aff_writer=>type_info-string act = cut->get_json_type_from_description( get_element_description( '' ) ) ).
   ENDMETHOD.
 
   METHOD get_type_info_string_like.

--- a/src/zcl_aff_writer.clas.testclasses.abap
+++ b/src/zcl_aff_writer.clas.testclasses.abap
@@ -187,7 +187,13 @@ CLASS ltcl_type_writer IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD get_type_info_string_like_enum.
-    cl_abap_unit_assert=>assert_equals( exp = zif_aff_writer=>type_info-string act = cut->get_json_type_from_description( get_element_description( '' ) ) ).
+    types:
+      begin of enum my_enum,
+        option1,
+        option2,
+      end of enum my_enum.
+
+    cl_abap_unit_assert=>assert_equals( exp = zif_aff_writer=>type_info-string act = cut->get_json_type_from_description( get_element_description( value my_enum( ) ) ) ).
   ENDMETHOD.
 
   METHOD get_type_info_string_like.

--- a/src/zcl_aff_writer_json_schema.clas.abap
+++ b/src/zcl_aff_writer_json_schema.clas.abap
@@ -64,7 +64,7 @@ CLASS zcl_aff_writer_json_schema DEFINITION
       get_json_schema_type
         IMPORTING element_name        TYPE string
                   element_description TYPE REF TO cl_abap_elemdescr
-                  json_type           TYPE zif_aff_writer=>enum_type_info
+                  json_type           TYPE string
         RETURNING VALUE(result)       TYPE string
         RAISING   zcx_aff_tools,
 
@@ -130,7 +130,7 @@ CLASS zcl_aff_writer_json_schema DEFINITION
       handle_default
         IMPORTING
           element_description TYPE REF TO cl_abap_elemdescr
-          json_type           TYPE zif_aff_writer=>enum_type_info
+          json_type           TYPE string
         RAISING
           zcx_aff_tools,
 

--- a/src/zcl_aff_writer_xslt.clas.abap
+++ b/src/zcl_aff_writer_xslt.clas.abap
@@ -62,7 +62,7 @@ CLASS zcl_aff_writer_xslt DEFINITION
 
     METHODS: get_tag_from_type
       IMPORTING
-        json_type     TYPE zif_aff_writer=>enum_type_info
+        json_type     TYPE string
       RETURNING
         VALUE(result) TYPE string
       RAISING
@@ -70,7 +70,7 @@ CLASS zcl_aff_writer_xslt DEFINITION
 
       get_option
         IMPORTING
-          json_type           TYPE zif_aff_writer=>enum_type_info
+          json_type           TYPE string
           element_description TYPE REF TO cl_abap_elemdescr
         RETURNING
           VALUE(result)       TYPE string
@@ -80,7 +80,7 @@ CLASS zcl_aff_writer_xslt DEFINITION
       write_value_mappings
         IMPORTING
           element_description TYPE REF TO cl_abap_elemdescr
-          json_type           TYPE zif_aff_writer=>enum_type_info
+          json_type           TYPE string
           element_name        TYPE string
           value_mapping       TYPE zif_aff_writer=>ty_abap_value_mapping
         RAISING
@@ -122,7 +122,7 @@ CLASS zcl_aff_writer_xslt DEFINITION
         IMPORTING
           element_name        TYPE string
           element_description TYPE REF TO cl_abap_elemdescr
-          type                TYPE zif_aff_writer=>enum_type_info
+          type                TYPE string
           value_mappings      TYPE zif_aff_writer=>ty_value_mappings
         RETURNING
           VALUE(condition)    TYPE string
@@ -141,7 +141,7 @@ CLASS zcl_aff_writer_xslt DEFINITION
       get_default_value_from_default
         IMPORTING
           value_mappings      TYPE zif_aff_writer=>ty_value_mappings
-          type                TYPE zif_aff_writer=>enum_type_info
+          type                TYPE string
           element_description TYPE REF TO cl_abap_elemdescr
         RETURNING
           VALUE(default)      TYPE string
@@ -177,7 +177,7 @@ CLASS zcl_aff_writer_xslt DEFINITION
           structure_name      TYPE string
           value_mappings      TYPE zif_aff_writer=>ty_value_mappings
           element_description TYPE REF TO cl_abap_elemdescr
-          type                TYPE zif_aff_writer=>enum_type_info
+          type                TYPE string
         RETURNING
           VALUE(default)      TYPE string
         RAISING

--- a/src/zcl_aff_writer_xslt.clas.testclasses.abap
+++ b/src/zcl_aff_writer_xslt.clas.testclasses.abap
@@ -894,7 +894,7 @@ CLASS ltcl_integration_test DEFINITION FINAL FOR TESTING
           test_type      TYPE data
           name_mappings  TYPE zif_aff_writer=>ty_name_mappings OPTIONAL
           value_mappings TYPE zif_aff_writer=>ty_abap_value_mappings OPTIONAL
-          formatting     TYPE zif_aff_writer=>enum_formatting_option DEFAULT zif_aff_writer=>formatting_option-no_formatting
+          formatting     TYPE string DEFAULT zif_aff_writer=>formatting_option-no_formatting
         EXPORTING
           VALUE(result)  TYPE string_table
           VALUE(json)    TYPE xstring

--- a/src/zcl_aff_writer_xslt.clas.testclasses.abap
+++ b/src/zcl_aff_writer_xslt.clas.testclasses.abap
@@ -490,10 +490,11 @@ CLASS ltcl_type_writer_xslt IMPLEMENTATION.
   METHOD value_mappings.
     DATA test_type TYPE lif_test_types=>element.
     cut->zif_aff_writer~set_abap_value_mappings( abap_value_mappings = VALUE #( (
-                                                 abap_element = 'ELEMENT'
-                                                 value_mappings = VALUE #(
-                                                     ( abap = 'X' json = 'true' )
-                                                     ( abap = '' json = 'false' ) ) ) ) ).
+                                                   abap_element   = 'ELEMENT'
+                                                   target_type    = zif_aff_writer=>type_info-string
+                                                   value_mappings = VALUE #(
+                                                       ( abap = 'X' json = 'true' )
+                                                       ( abap = '' json = 'false' ) ) ) ) ).
 
     DATA(act_output) = test_generator->generate_type( test_type ).
 
@@ -1334,10 +1335,11 @@ CLASS ltcl_integration_test IMPLEMENTATION.
       EXPORTING
         test_type      = test_type
         value_mappings = VALUE #(
-                            ( abap_element = 'ELEMENT'
-                                value_mappings = VALUE #(
-                                    ( abap = 'X' json = 'true' )
-                                    ( abap = '' json = 'false' ) ) ) )
+                            ( abap_element   = 'ELEMENT'
+                              target_type    = zif_aff_writer=>type_info-string
+                              value_mappings = VALUE #(
+                                  ( abap = 'X' json = 'true' )
+                                  ( abap = '' json = 'false' ) ) ) )
       IMPORTING
         result         = DATA(act_json)
         json           = DATA(json_xstring) ).

--- a/src/zif_aff_writer.intf.abap
+++ b/src/zif_aff_writer.intf.abap
@@ -1,29 +1,26 @@
 INTERFACE zif_aff_writer
   PUBLIC.
 
-  TYPES:
-    BEGIN OF ENUM enum_formatting_option STRUCTURE formatting_option,
-      no_formatting VALUE IS INITIAL,
-      camel_case    VALUE 1,
-    END OF ENUM enum_formatting_option STRUCTURE formatting_option.
+  CONSTANTS: BEGIN OF formatting_option,
+               no_formatting TYPE string VALUE 'no_formatting',
+               camel_case    TYPE string VALUE 'camel_case',
+             END OF formatting_option.
 
-  TYPES:
-    BEGIN OF ENUM enum_type_info STRUCTURE type_info,
-      string,
-      numeric,
-      boolean,
-      date_time,
-    END OF ENUM enum_type_info STRUCTURE type_info.
+  CONSTANTS: BEGIN OF  type_info,
+               string TYPE string VALUE 'string',
+               numeric TYPE string VALUE 'numeric',
+               boolean TYPE string VALUE 'boolean',
+               date_time TYPE string VALUE 'date_time',
+             END OF type_info.
 
-  TYPES:
-    BEGIN OF ENUM enum_operation STRUCTURE operation,
-      initial,
-      write_element,
-      open_structure,
-      close_structure,
-      open_table,
-      close_table,
-    END OF ENUM enum_operation STRUCTURE operation.
+  CONSTANTS: BEGIN OF operation,
+               initial TYPE string VALUE 'initial',
+               write_element TYPE string VALUE 'write_element',
+               open_structure TYPE string VALUE 'open_structure',
+               close_structure TYPE string VALUE 'close_structure',
+               open_table TYPE string VALUE 'open_table',
+               close_table TYPE string VALUE 'close_table',
+             END OF operation.
 
   TYPES:
     BEGIN OF ty_name_mapping,
@@ -42,7 +39,7 @@ INTERFACE zif_aff_writer
   TYPES:
     BEGIN OF ty_abap_value_mapping,
       abap_element   TYPE abap_compname,
-      target_type    TYPE enum_type_info,
+      target_type    TYPE string,
       value_mappings TYPE ty_value_mappings,
     END OF ty_abap_value_mapping,
     ty_abap_value_mappings TYPE HASHED TABLE OF ty_abap_value_mapping WITH UNIQUE KEY abap_element.
@@ -58,7 +55,7 @@ INTERFACE zif_aff_writer
 
     set_formatting_option
       IMPORTING
-        formatting_option TYPE zif_aff_writer=>enum_formatting_option,
+        formatting_option TYPE string,
 
     write_element
       IMPORTING


### PR DESCRIPTION
as per https://blogs.sap.com/2016/10/10/abap-news-release-7.51-enumerations/

> Normally, you are not interested in the contents of an enumerated object at all.

This PR removes use of ENUMS, as they are currently used for the purpose of their contents.

Note: I have not run the unit tests on a real system, `cl_oo_abap_doc_reader` does not exist on any system I have access to