### PR TITLE
Remove space for enums with integer value

### DIFF
--- a/src/zcl_aff_writer_xslt.clas.abap
+++ b/src/zcl_aff_writer_xslt.clas.abap
@@ -434,7 +434,7 @@ CLASS zcl_aff_writer_xslt IMPLEMENTATION.
 
 
   METHOD get_abap_value.
-    DATA  abap_value_copy TYPE string.
+    DATA abap_value_copy TYPE string.
     CASE element_description->type_kind.
       WHEN cl_abap_typedescr=>typekind_int OR cl_abap_typedescr=>typekind_int1 OR
            cl_abap_typedescr=>typekind_int2 OR cl_abap_typedescr=>typekind_int8.

--- a/src/zcl_aff_writer_xslt.clas.abap
+++ b/src/zcl_aff_writer_xslt.clas.abap
@@ -601,9 +601,12 @@ CLASS zcl_aff_writer_xslt IMPLEMENTATION.
 
 
   METHOD get_prefixed_default.
+    DATA value_copy TYPE string.
     CASE element_description->type_kind.
       WHEN cl_abap_typedescr=>typekind_int OR cl_abap_typedescr=>typekind_int1 OR cl_abap_typedescr=>typekind_int2.
-        result = |I({ value })|.
+        value_copy = value.
+        CONDENSE value_copy.
+        result = |I({ value_copy })|.
       WHEN cl_abap_typedescr=>typekind_int8.
         result = |INT8({ value })|.
       WHEN cl_abap_typedescr=>typekind_float.

--- a/src/zcl_aff_writer_xslt.clas.abap
+++ b/src/zcl_aff_writer_xslt.clas.abap
@@ -434,12 +434,16 @@ CLASS zcl_aff_writer_xslt IMPLEMENTATION.
 
 
   METHOD get_abap_value.
+    DATA  abap_value_copy TYPE string.
+    abap_value_copy = abap_value.
+    CONDENSE abap_value_copy.
     CASE element_description->type_kind.
       WHEN cl_abap_typedescr=>typekind_int OR cl_abap_typedescr=>typekind_int1 OR
            cl_abap_typedescr=>typekind_int2 OR cl_abap_typedescr=>typekind_int8.
-        result = |I({ abap_value })|.
+        CONDENSE result.
+        result = |I({ abap_value_copy })|.
       WHEN cl_abap_typedescr=>typekind_num.
-        result = |N('{ abap_value }')|.
+        result = |N('{ abap_value_copy }')|.
       WHEN OTHERS.
         result = |'{ abap_value }'|.
     ENDCASE.

--- a/src/zcl_aff_writer_xslt.clas.abap
+++ b/src/zcl_aff_writer_xslt.clas.abap
@@ -435,15 +435,14 @@ CLASS zcl_aff_writer_xslt IMPLEMENTATION.
 
   METHOD get_abap_value.
     DATA  abap_value_copy TYPE string.
-    abap_value_copy = abap_value.
-    CONDENSE abap_value_copy.
     CASE element_description->type_kind.
       WHEN cl_abap_typedescr=>typekind_int OR cl_abap_typedescr=>typekind_int1 OR
            cl_abap_typedescr=>typekind_int2 OR cl_abap_typedescr=>typekind_int8.
-        CONDENSE result.
+        abap_value_copy = abap_value.
+        CONDENSE abap_value_copy.
         result = |I({ abap_value_copy })|.
       WHEN cl_abap_typedescr=>typekind_num.
-        result = |N('{ abap_value_copy }')|.
+        result = |N('{ abap_value }')|.
       WHEN OTHERS.
         result = |'{ abap_value }'|.
     ENDCASE.


### PR DESCRIPTION
When using a constant with integer valued components, there has been added a space to the abap value. This space is removed now.