### PR TITLE
doc reader: add cache for scanned elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@abaplint/cli": "^2.93.13",
-        "@abaplint/database-sqlite": "^2.1.52",
-        "@abaplint/runtime": "^2.1.62",
-        "@abaplint/transpiler-cli": "^2.1.62",
+        "@abaplint/cli": "^2.93.15",
+        "@abaplint/database-sqlite": "^2.1.63",
+        "@abaplint/runtime": "^2.1.63",
+        "@abaplint/transpiler-cli": "^2.1.63",
         "abapmerge": "^0.14.7"
       }
     },
     "node_modules/@abaplint/cli": {
-      "version": "2.93.13",
-      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.93.13.tgz",
-      "integrity": "sha512-EqKThXGCEi3HbtynnQWWzc6hr1rkEdrbTqGVbYDotwoR/psDWKD+9IxkdG2wkHDevjWQlex0rPT7avX1wyu9DQ==",
+      "version": "2.93.15",
+      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.93.15.tgz",
+      "integrity": "sha512-DNWEg/aHf1SJRurIzjTrT8Z5cVRD01f4VnBNmmLbtB2YEgssY9bud2VyJFkXWMVnqq9YkTY1rvO/EO0K1MbUJw==",
       "bin": {
         "abaplint": "abaplint"
       },
@@ -28,25 +28,25 @@
       }
     },
     "node_modules/@abaplint/database-sqlite": {
-      "version": "2.1.52",
-      "resolved": "https://registry.npmjs.org/@abaplint/database-sqlite/-/database-sqlite-2.1.52.tgz",
-      "integrity": "sha512-/GihnJAnON4iFV8yylUrPnDMTv5FQcddozPI1QmuLo5O1XRq1BUr8AdPfumy0isUl3VxHatmH79DdzjYKt8ypg==",
+      "version": "2.1.63",
+      "resolved": "https://registry.npmjs.org/@abaplint/database-sqlite/-/database-sqlite-2.1.63.tgz",
+      "integrity": "sha512-ezt/gh98ZU4+dh+Az3/53Ld/zWSHZZvhcIqk9+TKJ3PaZaMi8FxeKJ+Dd+nOIpQyXECvFOOlAPkZOuwq9iKN6g==",
       "dependencies": {
         "sql.js": "^1.8.0"
       }
     },
     "node_modules/@abaplint/runtime": {
-      "version": "2.1.62",
-      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.1.62.tgz",
-      "integrity": "sha512-803xIPpHNgydk82cpg9rMxMv8cS9JIzDuhheV2CPxlNHnRfywVm2EX7gaEFmVHniFUHA0sqw5+5hcAcRm2cikQ==",
+      "version": "2.1.63",
+      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.1.63.tgz",
+      "integrity": "sha512-ufHeMUJT9EBWpjX6Dm6QMyeu+j5CHSGBz7acO8sFlmdYcW81PZKxg1drZYzlkiuB0gVPpA6d1bWG+7zD5BXqdQ==",
       "dependencies": {
         "temporal-polyfill": "^0.0.8"
       }
     },
     "node_modules/@abaplint/transpiler-cli": {
-      "version": "2.1.62",
-      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.1.62.tgz",
-      "integrity": "sha512-6wHjF4u2xh35hoG0pZL260HQ0gvJyDFtX3UltusDUt3kb6/rzH9Yft7xd7UFKNgIQPfWkApo7ztZpZ5bDhaPfw==",
+      "version": "2.1.63",
+      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.1.63.tgz",
+      "integrity": "sha512-TCymLet9sRHvERx8wYQjobQa36j/hN+urauWndzjX276A+rtw8FKbkaVc5rsxkFfhfIJJwY5/MWn8tKHWSJu8g==",
       "bin": {
         "abap_transpile": "abap_transpile"
       }
@@ -91,30 +91,30 @@
   },
   "dependencies": {
     "@abaplint/cli": {
-      "version": "2.93.13",
-      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.93.13.tgz",
-      "integrity": "sha512-EqKThXGCEi3HbtynnQWWzc6hr1rkEdrbTqGVbYDotwoR/psDWKD+9IxkdG2wkHDevjWQlex0rPT7avX1wyu9DQ=="
+      "version": "2.93.15",
+      "resolved": "https://registry.npmjs.org/@abaplint/cli/-/cli-2.93.15.tgz",
+      "integrity": "sha512-DNWEg/aHf1SJRurIzjTrT8Z5cVRD01f4VnBNmmLbtB2YEgssY9bud2VyJFkXWMVnqq9YkTY1rvO/EO0K1MbUJw=="
     },
     "@abaplint/database-sqlite": {
-      "version": "2.1.52",
-      "resolved": "https://registry.npmjs.org/@abaplint/database-sqlite/-/database-sqlite-2.1.52.tgz",
-      "integrity": "sha512-/GihnJAnON4iFV8yylUrPnDMTv5FQcddozPI1QmuLo5O1XRq1BUr8AdPfumy0isUl3VxHatmH79DdzjYKt8ypg==",
+      "version": "2.1.63",
+      "resolved": "https://registry.npmjs.org/@abaplint/database-sqlite/-/database-sqlite-2.1.63.tgz",
+      "integrity": "sha512-ezt/gh98ZU4+dh+Az3/53Ld/zWSHZZvhcIqk9+TKJ3PaZaMi8FxeKJ+Dd+nOIpQyXECvFOOlAPkZOuwq9iKN6g==",
       "requires": {
         "sql.js": "^1.8.0"
       }
     },
     "@abaplint/runtime": {
-      "version": "2.1.62",
-      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.1.62.tgz",
-      "integrity": "sha512-803xIPpHNgydk82cpg9rMxMv8cS9JIzDuhheV2CPxlNHnRfywVm2EX7gaEFmVHniFUHA0sqw5+5hcAcRm2cikQ==",
+      "version": "2.1.63",
+      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.1.63.tgz",
+      "integrity": "sha512-ufHeMUJT9EBWpjX6Dm6QMyeu+j5CHSGBz7acO8sFlmdYcW81PZKxg1drZYzlkiuB0gVPpA6d1bWG+7zD5BXqdQ==",
       "requires": {
         "temporal-polyfill": "^0.0.8"
       }
     },
     "@abaplint/transpiler-cli": {
-      "version": "2.1.62",
-      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.1.62.tgz",
-      "integrity": "sha512-6wHjF4u2xh35hoG0pZL260HQ0gvJyDFtX3UltusDUt3kb6/rzH9Yft7xd7UFKNgIQPfWkApo7ztZpZ5bDhaPfw=="
+      "version": "2.1.63",
+      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.1.63.tgz",
+      "integrity": "sha512-TCymLet9sRHvERx8wYQjobQa36j/hN+urauWndzjX276A+rtw8FKbkaVc5rsxkFfhfIJJwY5/MWn8tKHWSJu8g=="
     },
     "abapmerge": {
       "version": "0.14.7",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@abaplint/cli": "^2.93.13",
-    "@abaplint/runtime": "^2.1.62",
-    "@abaplint/database-sqlite": "^2.1.52",
-    "@abaplint/transpiler-cli": "^2.1.62",
+    "@abaplint/cli": "^2.93.15",
+    "@abaplint/runtime": "^2.1.63",
+    "@abaplint/database-sqlite": "^2.1.63",
+    "@abaplint/transpiler-cli": "^2.1.63",
     "abapmerge": "^0.14.7"
   }
 }

--- a/src/zcl_aff_abap_doc_reader.clas.abap
+++ b/src/zcl_aff_abap_doc_reader.clas.abap
@@ -5,12 +5,12 @@ CLASS zcl_aff_abap_doc_reader DEFINITION
 
   PUBLIC SECTION.
 
-    CLASS-METHODS:
-      create_instance
-        IMPORTING
-          source        TYPE string_table
-        RETURNING
-          VALUE(result) TYPE REF TO zcl_aff_abap_doc_reader.
+    CLASS-METHODS create_instance
+      IMPORTING
+        !source       TYPE string_table
+        !name         TYPE string OPTIONAL
+      RETURNING
+        VALUE(result) TYPE REF TO zcl_aff_abap_doc_reader .
     METHODS get_abap_doc_for_element
       IMPORTING
         element_name  TYPE string

--- a/src/zcl_aff_abap_doc_reader.clas.locals_def.abap
+++ b/src/zcl_aff_abap_doc_reader.clas.locals_def.abap
@@ -11,6 +11,6 @@ TYPES:
     hook_relevant_tok_name_add   TYPE stokesx,
     hook_relevant_tok_type_stmnt TYPE stokesx,
     hook_relevant_tok_name_stmnt TYPE stokesx,
-  END OF ty_comment_block .
+  END OF ty_comment_block.
 TYPES:
   ty_comment_blocks TYPE STANDARD TABLE OF ty_comment_block WITH EMPTY KEY.

--- a/src/zcl_aff_abap_doc_reader.clas.locals_def.abap
+++ b/src/zcl_aff_abap_doc_reader.clas.locals_def.abap
@@ -1,0 +1,16 @@
+*"* use this source file for any type of declarations (class
+*"* definitions, interfaces or type declarations) you need for
+*"* components in the private section
+
+    TYPES:
+      BEGIN OF ty_comment_block,
+        tab_comments                 TYPE string_table,
+        column_first_comment         TYPE i,
+        hook_relevant_tok_type       TYPE stokesx,
+        hook_relevant_tok_name       TYPE stokesx,
+        hook_relevant_tok_name_add   TYPE stokesx,
+        hook_relevant_tok_type_stmnt TYPE stokesx,
+        hook_relevant_tok_name_stmnt TYPE stokesx,
+      END OF ty_comment_block .
+    TYPES:
+      ty_comment_blocks TYPE STANDARD TABLE OF ty_comment_block WITH EMPTY KEY.

--- a/src/zcl_aff_abap_doc_reader.clas.locals_def.abap
+++ b/src/zcl_aff_abap_doc_reader.clas.locals_def.abap
@@ -2,15 +2,15 @@
 *"* definitions, interfaces or type declarations) you need for
 *"* components in the private section
 
-    TYPES:
-      BEGIN OF ty_comment_block,
-        tab_comments                 TYPE string_table,
-        column_first_comment         TYPE i,
-        hook_relevant_tok_type       TYPE stokesx,
-        hook_relevant_tok_name       TYPE stokesx,
-        hook_relevant_tok_name_add   TYPE stokesx,
-        hook_relevant_tok_type_stmnt TYPE stokesx,
-        hook_relevant_tok_name_stmnt TYPE stokesx,
-      END OF ty_comment_block .
-    TYPES:
-      ty_comment_blocks TYPE STANDARD TABLE OF ty_comment_block WITH EMPTY KEY.
+TYPES:
+  BEGIN OF ty_comment_block,
+    tab_comments                 TYPE string_table,
+    column_first_comment         TYPE i,
+    hook_relevant_tok_type       TYPE stokesx,
+    hook_relevant_tok_name       TYPE stokesx,
+    hook_relevant_tok_name_add   TYPE stokesx,
+    hook_relevant_tok_type_stmnt TYPE stokesx,
+    hook_relevant_tok_name_stmnt TYPE stokesx,
+  END OF ty_comment_block .
+TYPES:
+  ty_comment_blocks TYPE STANDARD TABLE OF ty_comment_block WITH EMPTY KEY.

--- a/src/zcl_aff_abap_doc_reader.clas.locals_imp.abap
+++ b/src/zcl_aff_abap_doc_reader.clas.locals_imp.abap
@@ -8,18 +8,6 @@ CLASS lcl_section_source_comments DEFINITION
       ty_stokesx TYPE STANDARD TABLE OF stokesx .
     TYPES:
       ty_sstmnt TYPE TABLE OF sstmnt .
-    TYPES:
-      BEGIN OF ty_comment_block,
-        tab_comments                 TYPE string_table,
-        column_first_comment         TYPE i,
-        hook_relevant_tok_type       TYPE stokesx,
-        hook_relevant_tok_name       TYPE stokesx,
-        hook_relevant_tok_name_add   TYPE stokesx,
-        hook_relevant_tok_type_stmnt TYPE stokesx,
-        hook_relevant_tok_name_stmnt TYPE stokesx,
-      END OF ty_comment_block .
-    TYPES:
-      ty_comment_blocks TYPE STANDARD TABLE OF ty_comment_block WITH EMPTY KEY.
 
     METHODS scan_code
       IMPORTING

--- a/src/zcl_aff_writer.clas.abap
+++ b/src/zcl_aff_writer.clas.abap
@@ -745,9 +745,6 @@ CLASS zcl_aff_writer IMPLEMENTATION.
     IF is_valid = abap_false.
       log->add_warning( message_text = zif_aff_log=>co_msg114 component_name = fullname_of_type ).
     ENDIF.
-
-
-
   ENDMETHOD.
 
 

--- a/src/zcl_aff_writer.clas.abap
+++ b/src/zcl_aff_writer.clas.abap
@@ -434,7 +434,9 @@ CLASS zcl_aff_writer IMPLEMENTATION.
   METHOD call_reader_and_decode.
     DATA(ref) = cl_oo_factory=>create_instance( )->create_clif_source( name_of_source ).
     ref->get_source( IMPORTING source = DATA(source) ).
-    DATA(reader) = zcl_aff_abap_doc_reader=>create_instance( source ).
+    DATA(reader) = zcl_aff_abap_doc_reader=>create_instance(
+      name   = name_of_source
+      source = source ).
     TRY.
         DATA(result) = reader->get_abap_doc_for_element( element_name ).
 
@@ -743,6 +745,9 @@ CLASS zcl_aff_writer IMPLEMENTATION.
     IF is_valid = abap_false.
       log->add_warning( message_text = zif_aff_log=>co_msg114 component_name = fullname_of_type ).
     ENDIF.
+
+
+
   ENDMETHOD.
 
 


### PR DESCRIPTION
Add cache for scanned abap doc per class/interface in ZCL_AFF_ABAP_DOC_READER

On my 754 system, it took ~10 seconds to execute all unit tests, this is now down to ~3 seconds