### PR TITLE
Remove logic for value mappings

### DIFF
--- a/src/zcl_aff_writer.clas.abap
+++ b/src/zcl_aff_writer.clas.abap
@@ -30,7 +30,6 @@ CLASS zcl_aff_writer DEFINITION
       output                  TYPE string_table,
       formatting_option       TYPE string,
       name_mappings           TYPE zif_aff_writer=>ty_name_mappings,
-      abap_value_mappings     TYPE zif_aff_writer=>ty_abap_value_mappings,
       content                 TYPE string_table,
       stack_of_structure      TYPE tt_structure_stack,
       stack                   TYPE STANDARD TABLE OF ty_stack_entry,
@@ -41,12 +40,9 @@ CLASS zcl_aff_writer DEFINITION
       abap_doc                TYPE zcl_aff_abap_doc_parser=>abap_doc,
       fullname_of_type        TYPE string.
 
-    METHODS: get_value_mapping_for_element
-      IMPORTING abap_element  TYPE string
-      RETURNING VALUE(result) TYPE zif_aff_writer=>ty_abap_value_mapping,
-      map_and_format_name
-        IMPORTING name          TYPE string
-        RETURNING VALUE(result) TYPE string,
+    METHODS: map_and_format_name
+      IMPORTING name          TYPE string
+      RETURNING VALUE(result) TYPE string,
       get_json_type_from_description
         IMPORTING element_description TYPE REF TO cl_abap_elemdescr
         RETURNING VALUE(result)       TYPE string
@@ -244,11 +240,6 @@ CLASS zcl_aff_writer IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD zif_aff_writer~set_abap_value_mappings.
-    me->abap_value_mappings = abap_value_mappings.
-  ENDMETHOD.
-
-
   METHOD zif_aff_writer~set_name_mappings.
     me->name_mappings = name_mappings.
   ENDMETHOD.
@@ -256,18 +247,6 @@ CLASS zcl_aff_writer IMPLEMENTATION.
 
   METHOD zif_aff_writer~set_formatting_option.
     me->formatting_option = formatting_option.
-  ENDMETHOD.
-
-
-  METHOD get_value_mapping_for_element.
-    DATA(abap_element_upper) = to_upper( abap_element ).
-    DATA(abap_value_mappings_upper) = VALUE zif_aff_writer=>ty_abap_value_mappings(
-      FOR abap_value_mapping IN me->abap_value_mappings (
-        abap_element   = to_upper( abap_value_mapping-abap_element )
-        target_type    = abap_value_mapping-target_type
-        value_mappings = abap_value_mapping-value_mappings
-      ) ).
-    result = VALUE #( abap_value_mappings_upper[ abap_element = abap_element_upper ] OPTIONAL ) ##WARN_OK.
   ENDMETHOD.
 
 

--- a/src/zcl_aff_writer.clas.testclasses.abap
+++ b/src/zcl_aff_writer.clas.testclasses.abap
@@ -45,8 +45,6 @@ CLASS ltcl_type_writer DEFINITION FINAL FOR TESTING
       name_mapping_not_found FOR TESTING RAISING cx_static_check,
       name_mapping_and_camel_case FOR TESTING RAISING cx_static_check,
       get_output FOR TESTING RAISING cx_static_check,
-      value_mapping_found FOR TESTING RAISING cx_static_check,
-      value_mapping_not_found FOR TESTING RAISING cx_static_check,
       get_type_info_string_like FOR TESTING RAISING cx_static_check,
       get_type_info_string_like_enum FOR TESTING RAISING cx_static_check,
       get_type_info_boolean1 FOR TESTING RAISING cx_static_check,
@@ -55,7 +53,6 @@ CLASS ltcl_type_writer DEFINITION FINAL FOR TESTING
       get_type_info_numeric FOR TESTING RAISING cx_static_check,
       get_type_info_date_time FOR TESTING RAISING cx_static_check,
       set_name_mappings FOR TESTING RAISING cx_static_check,
-      set_abap_value_mappings FOR TESTING RAISING cx_static_check,
       set_formatting_option FOR TESTING RAISING cx_static_check,
       stack_stores_operations FOR TESTING RAISING cx_static_check,
       append_to_previous_line FOR TESTING RAISING cx_static_check,
@@ -99,14 +96,6 @@ CLASS ltcl_type_writer IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( exp = name_mappings act = cut->name_mappings ).
   ENDMETHOD.
 
-  METHOD set_abap_value_mappings.
-    DATA(abap_value_mappings) = VALUE zif_aff_writer=>ty_abap_value_mappings(
-      ( abap_element = 'ABAP_ELEMENT' value_mappings = VALUE #( ( abap = '1' json = '2' ) ) ) ).
-
-    cut->zif_aff_writer~set_abap_value_mappings( abap_value_mappings ).
-
-    cl_abap_unit_assert=>assert_equals( exp = abap_value_mappings act = cut->abap_value_mappings ).
-  ENDMETHOD.
 
   METHOD set_formatting_option.
     cut->zif_aff_writer~set_formatting_option( zif_aff_writer=>formatting_option-camel_case ).
@@ -164,32 +153,6 @@ CLASS ltcl_type_writer IMPLEMENTATION.
     DATA(act_name) = cut->map_and_format_name( 'MY_TEST_NAME_ABAP' ).
 
     cl_abap_unit_assert=>assert_equals( act = act_name exp = 'my_test_name_json' msg = |Actual was { act_name }, but expected is 'my_test_name_json'| ).
-  ENDMETHOD.
-
-  METHOD value_mapping_found.
-    DATA(value_mappings) = VALUE zif_aff_writer=>ty_value_mappings( ( abap = 'X' json = 'true' ) ( abap = ' ' json = 'false' ) ).
-    DATA(abap_value_mapping_1) = VALUE zif_aff_writer=>ty_abap_value_mapping(
-      abap_element   = 'MY_TEST_ELEMENT_1'
-      target_type    = zif_aff_writer=>type_info-boolean
-      value_mappings = value_mappings ).
-    DATA(abap_value_mapping_2) = VALUE zif_aff_writer=>ty_abap_value_mapping(
-      abap_element   = 'my_test_element_2'
-      target_type    = zif_aff_writer=>type_info-string ).
-
-    cut->abap_value_mappings = VALUE #( ( abap_value_mapping_1 ) ( abap_value_mapping_2 ) ).
-
-    DATA(act_abap_value_mapping) = cut->get_value_mapping_for_element( 'MY_TEST_element_1' ).
-
-    cl_abap_unit_assert=>assert_equals( exp = abap_value_mapping_1 act = act_abap_value_mapping ).
-  ENDMETHOD.
-
-  METHOD value_mapping_not_found.
-    DATA(exp_value_mappings) = VALUE zif_aff_writer=>ty_value_mappings( ( abap = 'X' json = 'true' ) ( abap = ' ' json = 'false' ) ).
-    cut->abap_value_mappings = VALUE #( ( abap_element = 'MY_TEST_ELEMENT_2' value_mappings = exp_value_mappings ) ).
-
-    DATA(act_value_mappings) = cut->get_value_mapping_for_element( 'MY_TEST_ELEMENT' ).
-
-    cl_abap_unit_assert=>assert_initial( act_value_mappings ).
   ENDMETHOD.
 
   METHOD get_type_info_string_like_enum.

--- a/src/zcl_aff_writer_json_schema.clas.abap
+++ b/src/zcl_aff_writer_json_schema.clas.abap
@@ -383,14 +383,12 @@ CLASS zcl_aff_writer_json_schema IMPLEMENTATION.
 
 
   METHOD handle_extrema.
-    IF get_value_mapping_for_element( element_name ) IS INITIAL.
-      get_extrema(
-        EXPORTING
-          element_description = element_description
-        IMPORTING
-          max                 = DATA(max_value)
-          min                 = DATA(min_value) ).
-    ENDIF.
+    get_extrema(
+      EXPORTING
+        element_description = element_description
+      IMPORTING
+        max                 = DATA(max_value)
+        min                 = DATA(min_value) ).
     DATA(multiple_of) = abap_doc-multiple_of.
 
     IF multiple_of IS INITIAL AND element_description->type_kind = cl_abap_typedescr=>typekind_packed.
@@ -657,21 +655,15 @@ CLASS zcl_aff_writer_json_schema IMPLEMENTATION.
 
 
   METHOD get_json_schema_type.
-    DATA(value_mapping) = get_value_mapping_for_element( element_name ).
-    IF value_mapping IS NOT INITIAL.
-      DATA(type) = value_mapping-target_type.
-    ELSE.
-      type = json_type.
-    ENDIF.
-    IF type = zif_aff_writer=>type_info-numeric.
+    IF json_type = zif_aff_writer=>type_info-numeric.
       result = 'number' ##NO_TEXT.
       IF type_is_integer( element_description ) = abap_true.
         result = 'integer'  ##NO_TEXT.
       ENDIF.
-    ELSEIF type = zif_aff_writer=>type_info-date_time.
+    ELSEIF json_type = zif_aff_writer=>type_info-date_time.
       result = 'string' ##NO_TEXT.
     ELSE.
-      result = to_lower( type ).
+      result = to_lower( json_type ).
     ENDIF.
   ENDMETHOD.
 
@@ -780,12 +772,7 @@ CLASS zcl_aff_writer_json_schema IMPLEMENTATION.
 
 
   METHOD get_enum_properties.
-    DATA(value_mapping) = get_value_mapping_for_element( element_name ).
-    IF value_mapping IS NOT INITIAL.
-      LOOP AT value_mapping-value_mappings ASSIGNING FIELD-SYMBOL(<mapping>).
-        INSERT VALUE #( value = <mapping>-json ) INTO TABLE result-values.
-      ENDLOOP.
-    ELSEIF abap_doc-enumvalues_link IS NOT INITIAL.
+    IF abap_doc-enumvalues_link IS NOT INITIAL.
       result = get_properties_from_structure( element_description->type_kind ).
     ELSE.
       IF get_json_type_from_description( element_description ) = zif_aff_writer=>type_info-boolean.
@@ -810,12 +797,7 @@ CLASS zcl_aff_writer_json_schema IMPLEMENTATION.
 
 
   METHOD get_enum_descriptions.
-    DATA(value_mapping) = get_value_mapping_for_element( element_name ).
-    IF value_mapping IS NOT INITIAL.
-      LOOP AT value_mapping-value_mappings ASSIGNING FIELD-SYMBOL(<mapping>).
-        APPEND <mapping>-json TO result.
-      ENDLOOP.
-    ELSEIF abap_doc-enumvalues_link IS NOT INITIAL.
+    IF abap_doc-enumvalues_link IS NOT INITIAL.
       result = enum_properties-descriptions.
     ELSE.
       element_description->get_ddic_fixed_values(

--- a/src/zcl_aff_writer_json_schema.clas.abap
+++ b/src/zcl_aff_writer_json_schema.clas.abap
@@ -73,8 +73,7 @@ CLASS zcl_aff_writer_json_schema DEFINITION
     METHODS: append_comma_to_prev_line,
 
       get_json_schema_type
-        IMPORTING element_name        TYPE string
-                  element_description TYPE REF TO cl_abap_elemdescr
+        IMPORTING element_description TYPE REF TO cl_abap_elemdescr
                   json_type           TYPE string
         RETURNING VALUE(result)       TYPE string
         RAISING   zcx_aff_tools,
@@ -96,15 +95,13 @@ CLASS zcl_aff_writer_json_schema DEFINITION
         RETURNING VALUE(result)    TYPE string,
 
       get_enum_properties
-        IMPORTING element_name        TYPE string
-                  element_description TYPE REF TO cl_abap_elemdescr
+        IMPORTING element_description TYPE REF TO cl_abap_elemdescr
         RETURNING VALUE(result)       TYPE ty_enum_properties
         RAISING
                   zcx_aff_tools,
 
       get_enum_descriptions
-        IMPORTING element_name        TYPE string
-                  element_description TYPE REF TO cl_abap_elemdescr
+        IMPORTING element_description TYPE REF TO cl_abap_elemdescr
                   enum_properties     TYPE ty_enum_properties
         RETURNING VALUE(result)       TYPE string_table,
 
@@ -150,8 +147,7 @@ CLASS zcl_aff_writer_json_schema DEFINITION
 
       handle_extrema
         IMPORTING
-          element_description TYPE REF TO cl_abap_elemdescr
-          element_name        TYPE string,
+          element_description TYPE REF TO cl_abap_elemdescr,
 
       handle_string
         IMPORTING
@@ -162,7 +158,6 @@ CLASS zcl_aff_writer_json_schema DEFINITION
       handle_enums
         IMPORTING
           element_description TYPE REF TO cl_abap_elemdescr
-          element_name        TYPE string
           enum_properties     TYPE ty_enum_properties,
 
       write_subschema
@@ -256,7 +251,7 @@ CLASS zcl_aff_writer_json_schema IMPLEMENTATION.
       write_open_tag( |"{ mapped_and_formatted_name }": \{| ).
     ENDIF.
 
-    DATA(enum_properties) = get_enum_properties( element_name = element_name element_description = element_description ).
+    DATA(enum_properties) = get_enum_properties( element_description ).
     IF enum_properties IS NOT INITIAL.
       json_type = zif_aff_writer=>type_info-string.
     ENDIF.
@@ -273,17 +268,17 @@ CLASS zcl_aff_writer_json_schema IMPLEMENTATION.
       write_tag( `"type": "string",` ).
       write_tag( |"const": "{ format_version }",| ).
     ELSE.
-      write_tag( |"type": "{ get_json_schema_type( element_name = element_name element_description = element_description json_type = json_type ) }",| ).
+      write_tag( |"type": "{ get_json_schema_type( element_description = element_description json_type = json_type ) }",| ).
       DATA(format) = get_format( element_description ).
       IF format IS NOT INITIAL.
         write_tag( |"format": "{ format }",| ).
       ENDIF.
 
       IF enum_properties IS NOT INITIAL.
-        handle_enums( element_description = element_description element_name = element_name enum_properties = enum_properties ).
+        handle_enums( element_description = element_description enum_properties = enum_properties ).
       ELSE. "non- enum
         IF json_type = zif_aff_writer=>type_info-numeric.
-          handle_extrema( element_description = element_description element_name = element_name ).
+          handle_extrema( element_description ).
         ELSEIF json_type = zif_aff_writer=>type_info-string AND NOT ( element_description->type_kind = cl_abap_typedescr=>typekind_date OR element_description->type_kind = cl_abap_typedescr=>typekind_time OR
              element_description->type_kind = cl_abap_typedescr=>typekind_utclong ).
           IF is_sy_langu( element_description ).
@@ -344,7 +339,7 @@ CLASS zcl_aff_writer_json_schema IMPLEMENTATION.
       write_enum_properties( enum_properties-titles ).
     ENDIF.
 
-    DATA(enum_descr) = get_enum_descriptions( element_name = element_name element_description = element_description enum_properties = enum_properties ).
+    DATA(enum_descr) = get_enum_descriptions( element_description = element_description enum_properties = enum_properties ).
     write_tag( `"enumDescriptions": [` ).
     write_enum_properties( enum_descr ).
   ENDMETHOD.

--- a/src/zcl_aff_writer_xslt.clas.testclasses.abap
+++ b/src/zcl_aff_writer_xslt.clas.testclasses.abap
@@ -24,7 +24,7 @@ INTERFACE lif_test_types.
   TYPES:
     BEGIN OF include_in_include.
       INCLUDE TYPE include.
-  TYPES END OF include_in_include.
+TYPES END OF include_in_include.
 
   TYPES:
     BEGIN OF structure_include_in_include.
@@ -790,13 +790,12 @@ CLASS ltcl_integration_test DEFINITION FINAL FOR TESTING
 
       from_abap_to_json
         IMPORTING
-          test_type      TYPE data
-          name_mappings  TYPE zif_aff_writer=>ty_name_mappings OPTIONAL
-          value_mappings TYPE zif_aff_writer=>ty_abap_value_mappings OPTIONAL
-          formatting     TYPE string DEFAULT zif_aff_writer=>formatting_option-no_formatting
+          test_type     TYPE data
+          name_mappings TYPE zif_aff_writer=>ty_name_mappings OPTIONAL
+          formatting    TYPE string DEFAULT zif_aff_writer=>formatting_option-no_formatting
         EXPORTING
-          VALUE(result)  TYPE string_table
-          VALUE(json)    TYPE xstring
+          VALUE(result) TYPE string_table
+          VALUE(json)   TYPE xstring
         RAISING
           cx_static_check
           cx_sxml_illegal_argument_error,
@@ -820,7 +819,6 @@ CLASS ltcl_integration_test IMPLEMENTATION.
 
     cut->zif_aff_writer~set_formatting_option( formatting ).
     cut->zif_aff_writer~set_name_mappings( name_mappings ).
-    cut->zif_aff_writer~set_abap_value_mappings( value_mappings ).
 
     DATA(test_generator) = NEW zcl_aff_generator( cut ).
     DATA(st_content) = test_generator->generate_type( test_type ).
@@ -2093,7 +2091,7 @@ CLASS ltcl_type_writer_xslt_ad IMPLEMENTATION.
     log = cut->zif_aff_writer~get_log( ).
     zcl_aff_tools_unit_test_helper=>assert_log_contains_text(
       log                = log
-      exp_text          = `Annotation $default for type UTCLONG is not supported`
+      exp_text           = `Annotation $default for type UTCLONG is not supported`
       exp_component_name = `STRUCTURE_DIFFERENT_DEFAULT-DATE_TIME_FIELD`
       exp_type           = zif_aff_log=>c_message_type-warning ).
   ENDMETHOD.

--- a/src/zcl_aff_writer_xslt.clas.testclasses.abap
+++ b/src/zcl_aff_writer_xslt.clas.testclasses.abap
@@ -24,7 +24,7 @@ INTERFACE lif_test_types.
   TYPES:
     BEGIN OF include_in_include.
       INCLUDE TYPE include.
-TYPES END OF include_in_include.
+  TYPES END OF include_in_include.
 
   TYPES:
     BEGIN OF structure_include_in_include.

--- a/src/zif_aff_writer.intf.abap
+++ b/src/zif_aff_writer.intf.abap
@@ -7,19 +7,19 @@ INTERFACE zif_aff_writer
              END OF formatting_option.
 
   CONSTANTS: BEGIN OF  type_info,
-               string TYPE string VALUE 'string',
-               numeric TYPE string VALUE 'numeric',
-               boolean TYPE string VALUE 'boolean',
+               string    TYPE string VALUE 'string',
+               numeric   TYPE string VALUE 'numeric',
+               boolean   TYPE string VALUE 'boolean',
                date_time TYPE string VALUE 'date_time',
              END OF type_info.
 
   CONSTANTS: BEGIN OF operation,
-               initial TYPE string VALUE 'initial',
-               write_element TYPE string VALUE 'write_element',
-               open_structure TYPE string VALUE 'open_structure',
+               initial         TYPE string VALUE 'initial',
+               write_element   TYPE string VALUE 'write_element',
+               open_structure  TYPE string VALUE 'open_structure',
                close_structure TYPE string VALUE 'close_structure',
-               open_table TYPE string VALUE 'open_table',
-               close_table TYPE string VALUE 'close_table',
+               open_table      TYPE string VALUE 'open_table',
+               close_table     TYPE string VALUE 'close_table',
              END OF operation.
 
   TYPES:
@@ -29,29 +29,11 @@ INTERFACE zif_aff_writer
     END OF ty_name_mapping,
     ty_name_mappings TYPE HASHED TABLE OF ty_name_mapping WITH UNIQUE KEY abap.
 
-  TYPES:
-    BEGIN OF ty_value_mapping,
-      abap TYPE string,
-      json TYPE string,
-    END OF ty_value_mapping,
-    ty_value_mappings TYPE HASHED TABLE OF ty_value_mapping WITH UNIQUE KEY abap.
-
-  TYPES:
-    BEGIN OF ty_abap_value_mapping,
-      abap_element   TYPE abap_compname,
-      target_type    TYPE string,
-      value_mappings TYPE ty_value_mappings,
-    END OF ty_abap_value_mapping,
-    ty_abap_value_mappings TYPE HASHED TABLE OF ty_abap_value_mapping WITH UNIQUE KEY abap_element.
 
   METHODS:
     set_name_mappings
       IMPORTING
         name_mappings TYPE ty_name_mappings,
-
-    set_abap_value_mappings
-      IMPORTING
-        abap_value_mappings TYPE ty_abap_value_mappings,
 
     set_formatting_option
       IMPORTING


### PR DESCRIPTION
The logic for setting value mappings is not necessary anymore. 

One can provide such mappings via using the enum/constant logic for a component.