### PR TITLE
Fix abap doc reader

### DIFF
--- a/src/zcl_aff_abap_doc_reader.clas.locals_imp.abap
+++ b/src/zcl_aff_abap_doc_reader.clas.locals_imp.abap
@@ -237,7 +237,7 @@ CLASS lcl_section_source_comments IMPLEMENTATION.
 
         DATA(l_line_code_condensed) = l_line_code.
         CONDENSE l_line_code_condensed.
-        IF strlen( l_line_code_condensed ) >= 2 and l_line_code_condensed(2) = '"!'.           " filter only ABAP Doc comments
+        IF strlen( l_line_code_condensed ) >= 2 AND l_line_code_condensed(2) = '"!'.           " filter only ABAP Doc comments
           APPEND l_line_code TO tab_comments_to_save.
         ENDIF.
       ENDLOOP.

--- a/src/zcl_aff_abap_doc_reader.clas.locals_imp.abap
+++ b/src/zcl_aff_abap_doc_reader.clas.locals_imp.abap
@@ -237,7 +237,7 @@ CLASS lcl_section_source_comments IMPLEMENTATION.
 
         DATA(l_line_code_condensed) = l_line_code.
         CONDENSE l_line_code_condensed.
-        IF l_line_code_condensed(2) = '"!'.           " filter only ABAP Doc comments
+        IF strlen( l_line_code_condensed ) >= 2 and l_line_code_condensed(2) = '"!'.           " filter only ABAP Doc comments
           APPEND l_line_code TO tab_comments_to_save.
         ENDIF.
       ENDLOOP.


### PR DESCRIPTION
ABAP Doc comment blocks cannot be identified within a class. An exception is raised in the method IDENTIFY_ABAP_DOC_BLOCKS_ALL, within class CL_OO_SECTION_SOURCE_COMMENTS.
This is fixed by this PR