### PR TITLE
Fix replacing of names in generator

### DIFF
--- a/src/z_generate_json_schema.prog.xml
+++ b/src/z_generate_json_schema.prog.xml
@@ -48,47 +48,6 @@
      <LENGTH>38</LENGTH>
     </item>
    </TPOOL>
-   <I18N_TPOOL>
-    <item>
-     <LANGUAGE>B</LANGUAGE>
-     <TEXTPOOL>
-      <item>
-       <ID>S</ID>
-       <KEY>P_OBJTYP</KEY>
-       <ENTRY>סוג אובייקט</ENTRY>
-       <LENGTH>38</LENGTH>
-      </item>
-      <item>
-       <ID>S</ID>
-       <KEY>P_TYPE</KEY>
-       <ENTRY>שם סוג</ENTRY>
-       <LENGTH>38</LENGTH>
-      </item>
-     </TEXTPOOL>
-    </item>
-    <item>
-     <LANGUAGE>D</LANGUAGE>
-     <TEXTPOOL>
-      <item>
-       <ID>I</ID>
-       <KEY>000</KEY>
-       <ENTRY>Einstellungen</ENTRY>
-       <LENGTH>17</LENGTH>
-      </item>
-      <item>
-       <ID>I</ID>
-       <KEY>001</KEY>
-       <ENTRY>Verwaiste Daten löschen:</ENTRY>
-       <LENGTH>42</LENGTH>
-      </item>
-      <item>
-       <ID>R</ID>
-       <ENTRY>Testlauf</ENTRY>
-       <LENGTH>70</LENGTH>
-      </item>
-     </TEXTPOOL>
-    </item>
-   </I18N_TPOOL>
   </asx:values>
  </asx:abap>
 </abapGit>

--- a/src/z_generate_json_schema.prog.xml
+++ b/src/z_generate_json_schema.prog.xml
@@ -50,6 +50,23 @@
    </TPOOL>
    <I18N_TPOOL>
     <item>
+     <LANGUAGE>B</LANGUAGE>
+     <TEXTPOOL>
+      <item>
+       <ID>S</ID>
+       <KEY>P_OBJTYP</KEY>
+       <ENTRY>סוג אובייקט</ENTRY>
+       <LENGTH>38</LENGTH>
+      </item>
+      <item>
+       <ID>S</ID>
+       <KEY>P_TYPE</KEY>
+       <ENTRY>שם סוג</ENTRY>
+       <LENGTH>38</LENGTH>
+      </item>
+     </TEXTPOOL>
+    </item>
+    <item>
      <LANGUAGE>D</LANGUAGE>
      <TEXTPOOL>
       <item>

--- a/src/z_generate_repo.prog.abap
+++ b/src/z_generate_repo.prog.abap
@@ -553,23 +553,18 @@ CLASS lcl_generator IMPLEMENTATION.
   METHOD replace_names_in_string.
     DATA(string_content) = content_as_string.
     LOOP AT replacing_table_string ASSIGNING FIELD-SYMBOL(<replace_string>).
-      FIND ALL OCCURRENCES OF <replace_string>-to_be_replaced IN string_content IGNORING CASE RESULTS DATA(table).
+      FIND ALL OCCURRENCES OF <replace_string>-to_be_replaced IN string_content IGNORING CASE RESULTS DATA(findings).
 *      replace all occurrences of <replace_string>-to_be_replaced in string_content with <replace_string>-replace_with ignoring case.
-      DATA(counter_replaced) = 0.
-      LOOP AT table ASSIGNING FIELD-SYMBOL(<finding>).
+      LOOP AT findings ASSIGNING FIELD-SYMBOL(<finding>) step -1.
         IF <finding>-offset > 0.
-          DATA(offset) = <finding>-offset + counter_replaced.
-          DATA(before_offset) = offset - 1.
+          DATA(before_offset) = <finding>-offset - 1.
           DATA(char_before_offset) = to_lower( string_content+before_offset(1) ).
         ELSE.
           char_before_offset = ' '.
-          offset = 0.
         ENDIF.
         IF NOT to_lower( char_before_offset ) EQ 'z'.
-*          string_content = insert( val = string_content sub = 'z' off = offset ).
 *         make the object names to lower
-          REPLACE SECTION OFFSET offset LENGTH <finding>-length OF string_content WITH <replace_string>-replace_with.
-          counter_replaced += 1.
+          REPLACE SECTION OFFSET <finding>-offset LENGTH <finding>-length OF string_content WITH <replace_string>-replace_with.
         ENDIF.
       ENDLOOP.
     ENDLOOP.

--- a/src/z_generate_repo.prog.abap
+++ b/src/z_generate_repo.prog.abap
@@ -563,7 +563,6 @@ CLASS lcl_generator IMPLEMENTATION.
           char_before_offset = ' '.
         ENDIF.
         IF NOT to_lower( char_before_offset ) EQ 'z'.
-*         make the object names to lower
           REPLACE SECTION OFFSET <finding>-offset LENGTH <finding>-length OF string_content WITH <replace_string>-replace_with.
         ENDIF.
       ENDLOOP.

--- a/src/z_generate_repo.prog.xml
+++ b/src/z_generate_repo.prog.xml
@@ -92,6 +92,35 @@
    </TPOOL>
    <I18N_TPOOL>
     <item>
+     <LANGUAGE>B</LANGUAGE>
+     <TEXTPOOL>
+      <item>
+       <ID>I</ID>
+       <KEY>021</KEY>
+       <ENTRY>מידע אובייקט</ENTRY>
+       <LENGTH>20</LENGTH>
+      </item>
+      <item>
+       <ID>S</ID>
+       <KEY>P_INTF</KEY>
+       <ENTRY>שם ממשק</ENTRY>
+       <LENGTH>38</LENGTH>
+      </item>
+      <item>
+       <ID>S</ID>
+       <KEY>P_OBJTYP</KEY>
+       <ENTRY>סוג אובייקט</ENTRY>
+       <LENGTH>38</LENGTH>
+      </item>
+      <item>
+       <ID>S</ID>
+       <KEY>P_TYPE</KEY>
+       <ENTRY>שם סוג</ENTRY>
+       <LENGTH>38</LENGTH>
+      </item>
+     </TEXTPOOL>
+    </item>
+    <item>
      <LANGUAGE>D</LANGUAGE>
      <TEXTPOOL>
       <item>

--- a/src/z_generate_repo.prog.xml
+++ b/src/z_generate_repo.prog.xml
@@ -90,59 +90,6 @@
      <LENGTH>15</LENGTH>
     </item>
    </TPOOL>
-   <I18N_TPOOL>
-    <item>
-     <LANGUAGE>B</LANGUAGE>
-     <TEXTPOOL>
-      <item>
-       <ID>I</ID>
-       <KEY>021</KEY>
-       <ENTRY>מידע אובייקט</ENTRY>
-       <LENGTH>20</LENGTH>
-      </item>
-      <item>
-       <ID>S</ID>
-       <KEY>P_INTF</KEY>
-       <ENTRY>שם ממשק</ENTRY>
-       <LENGTH>38</LENGTH>
-      </item>
-      <item>
-       <ID>S</ID>
-       <KEY>P_OBJTYP</KEY>
-       <ENTRY>סוג אובייקט</ENTRY>
-       <LENGTH>38</LENGTH>
-      </item>
-      <item>
-       <ID>S</ID>
-       <KEY>P_TYPE</KEY>
-       <ENTRY>שם סוג</ENTRY>
-       <LENGTH>38</LENGTH>
-      </item>
-     </TEXTPOOL>
-    </item>
-    <item>
-     <LANGUAGE>D</LANGUAGE>
-     <TEXTPOOL>
-      <item>
-       <ID>I</ID>
-       <KEY>000</KEY>
-       <ENTRY>Einstellungen</ENTRY>
-       <LENGTH>17</LENGTH>
-      </item>
-      <item>
-       <ID>I</ID>
-       <KEY>001</KEY>
-       <ENTRY>Verwaiste Daten löschen:</ENTRY>
-       <LENGTH>42</LENGTH>
-      </item>
-      <item>
-       <ID>R</ID>
-       <ENTRY>Testlauf</ENTRY>
-       <LENGTH>70</LENGTH>
-      </item>
-     </TEXTPOOL>
-    </item>
-   </I18N_TPOOL>
    <LONGTEXTS>
     <item>
      <DOKIL>


### PR DESCRIPTION
Interfaces with namespaces had not been replaced correctly since new offset was calculated wrong.

I reverted the order of the loop over the findings so that replacing a name does not influence the offset of the remaining findings.