### PR TITLE
Create reusable include for AFF generation

### DIFF
--- a/.github/workflows/upload-standalone.yml
+++ b/.github/workflows/upload-standalone.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  build-merged:
+  create-generateRepo:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -17,10 +17,27 @@ jobs:
     - name: Run npm steps
       run: |
         npm install
-        npm run merge
+        npm run createGenerateRepo
         npm run cutUnitTests
     - name: Upload build artifact
       uses: actions/upload-artifact@v3
       with:
         name: saff_generate_repo.prog.abap
         path: saff_generate_repo.prog.abap
+  create-generatorInclude:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+    - name: Run npm steps
+      run: |
+        npm install
+        npm run createGeneratorInclude
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: saff_generator.prog.abap
+        path: saff_generator.prog.abap

--- a/.github/workflows/upload-standalone.yml
+++ b/.github/workflows/upload-standalone.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   create-generateRepo:

--- a/.github/workflows/upload-standalone.yml
+++ b/.github/workflows/upload-standalone.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   create-generateRepo:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "unit": "npm run build && echo RUNNING && node output/index.mjs",
     "test": "npm run lint && npm run downport && npm run unit",
     "downport": "rm -rf downport && cp -r src downport && cp deps/* downport && rm downport/*.prog.* && rm downport/zcl_aff_writer_xslt.clas.testclasses.abap && abaplint --fix abaplint-downport.jsonc",
-    "merge": "rm -f src/z_generate_json_schema.prog.abap && abapmerge -f src/z_generate_repo.prog.abap -c saff_generate_repo > saff_generate_repo.prog.abap",
+    "createGenerateRepo": "rm -f src/z_generate_json_schema.prog.abap src/z_aff_generator.prog.abap && abapmerge -f src/z_generate_repo.prog.abap -c saff_generate_repo > saff_generate_repo.prog.abap",
+    "createGeneratorInclude": "rm -f src/z_generate_json_schema.prog.abap src/z_generate_repo.prog.abap && echo 'REPORT z_aff_generator.' | cat - src/z_aff_generator.prog.abap > temp && mv temp src/z_aff_generator.prog.abap && abapmerge -f src/z_aff_generator.prog.abap -c saff_generator > saff_generator.prog.abap && tail -n +2 saff_generator.prog.abap > tmp && mv tmp saff_generator.prog.abap",
     "aff": "npm run downport && rm -rf abap-file-formats && git clone https://github.com/SAP/abap-file-formats && cp abap-file-formats/file-formats/*.abap downport && cp abap-file-formats/file-formats/*/type/*.abap downport && cp test/cl_run.clas.abap downport && abap_transpile test/abap_transpile.json && node test/aff.mjs",
     "cutUnitTests": "sed -i '/CLASS\\ ltcl_generator\\ I/,/ENDCLASS./d' saff_generate_repo.prog.abap && sed -i '/CLASS\\ ltcl_generator\\ D/,/ENDCLASS./d' saff_generate_repo.prog.abap"
   },

--- a/src/z_aff_generator.prog.abap
+++ b/src/z_aff_generator.prog.abap
@@ -1,0 +1,46 @@
+CLASS lcl_aff_generator DEFINITION CREATE PRIVATE.
+
+  PUBLIC SECTION.
+    CLASS-METHODS:
+      "! Generates the AFF JSON schema.
+      "!
+      "! @parameter schema_id | The id that should be written in the $id field of the schema
+      "! @parameter data | The type where the schema should be generated from
+      "! @parameter format_version | The version of the ABAP file format as integer
+      "! @parameter result | The generated schema as string
+      generate_schema
+        IMPORTING schema_id      TYPE string
+                  data           TYPE data
+                  format_version TYPE i
+        RETURNING VALUE(result)  TYPE string
+        RAISING   zcx_aff_tools,
+
+      "! Generates the AFF XSLT transformation.
+      "!
+      "! @parameter data | The type where the schema should be generated from
+      "! @parameter result | The generated XSLT as string
+      generate_xslt
+        IMPORTING data          TYPE data
+        RETURNING VALUE(result) TYPE string
+        RAISING   zcx_aff_tools.
+
+ENDCLASS.
+
+CLASS lcl_aff_generator IMPLEMENTATION.
+
+  METHOD generate_schema.
+    DATA(schema_writer) = NEW zcl_aff_writer_json_schema( schema_id      = schema_id
+                                                          format_version = format_version ).
+    DATA(generator) = NEW zcl_aff_generator( schema_writer ).
+    DATA(result_table) = generator->zif_aff_generator~generate_type( data ).
+    CONCATENATE LINES OF result_table INTO result SEPARATED BY cl_abap_char_utilities=>newline.
+  ENDMETHOD.
+
+  METHOD generate_xslt.
+    DATA(xslt_writer) = NEW zcl_aff_writer_xslt( ).
+    DATA(generator) = NEW zcl_aff_generator( xslt_writer ).
+    DATA(result_table) = generator->zif_aff_generator~generate_type( data ).
+    CONCATENATE LINES OF result_table INTO result SEPARATED BY cl_abap_char_utilities=>newline.
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/z_aff_generator.prog.xml
+++ b/src/z_aff_generator.prog.xml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_PROG" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <PROGDIR>
+    <NAME>Z_AFF_GENERATOR</NAME>
+    <DBAPL>S</DBAPL>
+    <DBNA>D$</DBNA>
+    <SUBC>I</SUBC>
+    <FIXPT>X</FIXPT>
+    <LDBNAME>D$S</LDBNAME>
+    <UCCHECK>X</UCCHECK>
+   </PROGDIR>
+   <TPOOL>
+    <item>
+     <ID>R</ID>
+     <ENTRY>Reuse include for AFF generator</ENTRY>
+     <LENGTH>31</LENGTH>
+    </item>
+   </TPOOL>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/z_generate_json_schema.prog.abap
+++ b/src/z_generate_json_schema.prog.abap
@@ -4,6 +4,9 @@
 *&
 *&---------------------------------------------------------------------*
 REPORT z_generate_json_schema.
+
+INCLUDE z_aff_generator.
+
 CLASS lcl_generator_helper DEFINITION
  FINAL
  CREATE PUBLIC.
@@ -45,23 +48,16 @@ CLASS lcl_generator_helper IMPLEMENTATION.
 
     ASSIGN my_type->* TO <field>.
 
-    DATA(format_version) = get_format_version( interface_name ).
-    DATA(object_type_path) = get_object_type_path( interface_name ).
-    DATA(schema_id) = |https://github.com/SAP/abap-file-formats/blob/main/file-formats/{ object_type_path }-v{ format_version }.json| ##NO_TEXT.
-
-
-    DATA writer TYPE REF TO zcl_aff_writer.
-    " set up the writer
     IF generate_schema = abap_true.
-      writer = NEW zcl_aff_writer_json_schema( schema_id = schema_id format_version = format_version ).
+      DATA(format_version) = get_format_version( interface_name ).
+      DATA(object_type_path) = get_object_type_path( interface_name ).
+      DATA(schema_id) = |https://github.com/SAP/abap-file-formats/blob/main/file-formats/{ object_type_path }-v{ format_version }.json| ##NO_TEXT.
+      result = lcl_aff_generator=>generate_schema( schema_id      = schema_id
+                                                   data           = <field>
+                                                   format_version = format_version ).
     ELSE.
-      writer = NEW zcl_aff_writer_xslt( ).
+      result = lcl_aff_generator=>generate_xslt( <field> ).
     ENDIF.
-
-    DATA(generator) = NEW zcl_aff_generator( writer ).
-    DATA(result_table) = generator->zif_aff_generator~generate_type( <field> ).
-    CONCATENATE LINES OF result_table INTO result SEPARATED BY cl_abap_char_utilities=>newline.
-
   ENDMETHOD.
 
   METHOD get_format_version.


### PR DESCRIPTION
The AFF generators will be needed in SAP BASIS coding. To be able to reuse the open sourced generators, one single include is created to export the generator functionality.